### PR TITLE
Refactor island delta.

### DIFF
--- a/include/edyn/comp/shared_comp.hpp
+++ b/include/edyn/comp/shared_comp.hpp
@@ -1,7 +1,6 @@
 #ifndef EDYN_SHARED_COMP_HPP
 #define EDYN_SHARED_COMP_HPP
 
-#include "edyn/util/tuple_util.hpp"
 #include "edyn/comp/aabb.hpp"
 #include "edyn/comp/linacc.hpp"
 #include "edyn/comp/linvel.hpp"
@@ -10,8 +9,6 @@
 #include "edyn/comp/inertia.hpp"
 #include "edyn/comp/position.hpp"
 #include "edyn/comp/orientation.hpp"
-#include "edyn/comp/present_position.hpp"
-#include "edyn/comp/present_orientation.hpp"
 #include "edyn/constraints/constraint.hpp"
 #include "edyn/constraints/constraint_impulse.hpp"
 #include "edyn/comp/tag.hpp"
@@ -21,6 +18,7 @@
 #include "edyn/comp/collision_filter.hpp"
 #include "edyn/comp/continuous.hpp"
 #include "edyn/shapes/shapes.hpp"
+#include "edyn/collision/tree_view.hpp"
 #include "edyn/collision/contact_manifold.hpp"
 #include "edyn/collision/contact_point.hpp"
 
@@ -57,7 +55,8 @@ static const auto shared_components = std::tuple_cat(std::tuple<
     sleeping_disabled_tag,
     disabled_tag,
     continuous_contacts_tag,
-    shape_index
+    shape_index,
+    tree_view
 >{}, constraints_tuple, shapes_tuple); // Concatenate with all shapes and constraints at the end.
 
 using shared_components_t = std::decay_t<decltype(shared_components)>;

--- a/include/edyn/edyn.hpp
+++ b/include/edyn/edyn.hpp
@@ -6,6 +6,8 @@
 #include "comp/dirty.hpp"
 #include "comp/graph_node.hpp"
 #include "comp/graph_edge.hpp"
+#include "comp/present_position.hpp"
+#include "comp/present_orientation.hpp"
 #include "math/constants.hpp"
 #include "math/scalar.hpp"
 #include "math/vector3.hpp"

--- a/include/edyn/parallel/component_index_source.hpp
+++ b/include/edyn/parallel/component_index_source.hpp
@@ -1,0 +1,49 @@
+#ifndef EDYN_PARALLEL_COMPONENT_INDEX_SOURCE_HPP
+#define EDYN_PARALLEL_COMPONENT_INDEX_SOURCE_HPP
+
+#include "edyn/comp/shared_comp.hpp"
+#include "edyn/util/tuple_util.hpp"
+#include <entt/fwd.hpp>
+#include <entt/core/type_info.hpp>
+
+namespace edyn {
+
+/**
+ * Provides a means to obtain a stable index for each component type, both
+ * standard and external. The indices correspond to the location of the
+ * component in the tuple of components.
+ */
+struct component_index_source {
+    virtual ~component_index_source() = default;
+
+    template<typename Component>
+    size_t index_of() const {
+        if constexpr(has_type<Component, shared_components_t>::value) {
+            return tuple_index_of<Component>(shared_components);
+        } else {
+            // Get external component index by `entt::type_index`.
+            return index_of_id(entt::type_index<Component>::value());
+        }
+    }
+
+    virtual size_t index_of_id(entt::id_type id) const {
+        EDYN_ASSERT(false);
+    }
+};
+
+template<typename... Component>
+struct external_component_index_source : public component_index_source {
+    using components_tuple_t = std::tuple<Component...>;
+
+    size_t index_of_id(entt::id_type id) const override {
+        auto idx = SIZE_MAX;
+        ((entt::type_index<Component>::value() == id ?
+            (idx = edyn::index_of<size_t, Component, components_tuple_t>::value) : (size_t)0), ...);
+        EDYN_ASSERT(idx != SIZE_MAX);
+        return idx;
+    }
+};
+
+}
+
+#endif // EDYN_PARALLEL_COMPONENT_INDEX_SOURCE_HPP

--- a/include/edyn/serialization/file_archive.hpp
+++ b/include/edyn/serialization/file_archive.hpp
@@ -27,6 +27,10 @@ public:
         m_file.open(path, std::ios::binary | std::ios::in);
     }
 
+    void close() {
+        m_file.close();
+    }
+
     bool is_file_open() const {
         return m_file.is_open();
     }
@@ -97,10 +101,10 @@ public:
 
 private:
     template<typename T>
-    void write_bytes(T &t) { 
+    void write_bytes(T &t) {
         m_file.write(reinterpret_cast<char *>(&t), sizeof t);
     }
-    
+
     std::ofstream m_file;
 };
 

--- a/include/edyn/serialization/std_s11n.hpp
+++ b/include/edyn/serialization/std_s11n.hpp
@@ -118,7 +118,7 @@ void serialize(Archive& archive, std::variant<Ts...>& var) {
     } else {
         std::visit([&archive] (auto &&t) {
             using T = std::decay_t<decltype(t)>;
-            auto id = index_of<T, Ts...>();
+            auto id = index_of_v<size_t, T, Ts...>;
             archive(id);
             archive(t);
         }, var);

--- a/include/edyn/shapes/shapes.hpp
+++ b/include/edyn/shapes/shapes.hpp
@@ -50,7 +50,7 @@ using shapes_variant_t = std::decay_t<decltype(shapes_variant)>;
  */
 template<typename ShapeType>
 constexpr size_t get_shape_index() {
-    return index_of<ShapeType>(shapes_tuple);
+    return tuple_index_of<ShapeType>(shapes_tuple);
 }
 
 /**

--- a/include/edyn/util/tuple_util.hpp
+++ b/include/edyn/util/tuple_util.hpp
@@ -21,34 +21,30 @@ struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
 template <typename T, typename... Us>
 struct has_type<T, std::variant<Us...>> : std::disjunction<std::is_same<T, Us>...> {};
 
-namespace detail {
-    template<typename IndexType, typename T, typename... Ts>
-    struct index_of;
+template<typename IndexType, typename T, typename... Ts>
+struct index_of;
 
-    template<typename IndexType, typename T, typename... Ts>
-    struct index_of<IndexType, T, T, Ts...> : std::integral_constant<IndexType, 0>{};
+template<typename IndexType, typename T, typename... Ts>
+struct index_of<IndexType, T, T, Ts...> : std::integral_constant<IndexType, 0>{};
 
-    template<typename IndexType, typename T, typename U, typename... Ts>
-    struct index_of<IndexType, T, U, Ts...> : std::integral_constant<IndexType, 1 + index_of<IndexType, T, Ts...>::value>{};
+template<typename IndexType, typename T, typename U, typename... Ts>
+struct index_of<IndexType, T, U, Ts...> : std::integral_constant<IndexType, 1 + index_of<IndexType, T, Ts...>::value>{};
 
-    template<typename IndexType, typename T, typename... Ts>
-    static constexpr IndexType index_of_v = index_of<IndexType, T, Ts...>::value;
-}
+template<typename IndexType, typename T, typename... Ts>
+static constexpr IndexType index_of_v = index_of<IndexType, T, Ts...>::value;
 
 /**
- * Find index of a type in a template parameter pack.
+ * Find index of a type in a tuple type.
  */
-template<typename T, typename... Ts, typename IndexType = size_t>
-constexpr IndexType index_of() {
-    return detail::index_of_v<IndexType, T, Ts...>;
-}
+template<typename IndexType, typename T, typename... Ts>
+struct index_of<IndexType, T, std::tuple<Ts...>> : index_of<IndexType, T, Ts...>{};
 
 /**
  * Find index of a type in a tuple.
  */
 template<typename T, typename... Ts, typename IndexType = size_t>
-constexpr IndexType index_of(std::tuple<Ts...>) {
-    return index_of<T, Ts...>();
+constexpr IndexType tuple_index_of(std::tuple<Ts...>) {
+    return index_of_v<IndexType, T, Ts...>;
 }
 
 /**


### PR DESCRIPTION
Make component indices match their location in the shared components tuple. Do not rely on `entt::type_index`.