### PR TITLE
Set center of mass.

### DIFF
--- a/include/edyn/collision/narrowphase.hpp
+++ b/include/edyn/collision/narrowphase.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <entt/entity/fwd.hpp>
 #include "edyn/comp/aabb.hpp"
+#include "edyn/comp/center_of_mass.hpp"
 #include "edyn/comp/shape_index.hpp"
 #include "edyn/comp/position.hpp"
 #include "edyn/comp/orientation.hpp"
@@ -76,6 +77,7 @@ void narrowphase::update_contact_manifolds(Iterator begin, Iterator end,
                                            ContactManifoldView &manifold_view) {
     auto body_view = m_registry->view<AABB, shape_index, position, orientation>();
     auto tr_view = m_registry->view<position, orientation>();
+    auto com_view = m_registry->view<center_of_mass>();
     auto cp_view = m_registry->view<contact_point>();
     auto imp_view = m_registry->view<constraint_impulse>();
     auto views_tuple = get_tuple_of_shape_views(*m_registry);
@@ -84,9 +86,9 @@ void narrowphase::update_contact_manifolds(Iterator begin, Iterator end,
         entt::entity manifold_entity = *it;
         auto &manifold = manifold_view.get(manifold_entity);
         collision_result result;
-        detect_collision(manifold.body, result, body_view, views_tuple);
+        detect_collision(manifold.body, result, body_view, com_view, views_tuple);
 
-        process_collision(manifold_entity, manifold, result, cp_view, imp_view, tr_view,
+        process_collision(manifold_entity, manifold, result, cp_view, imp_view, tr_view, com_view,
                           [&] (const collision_result::collision_point &rp) {
             auto contact_entity = create_contact_point(*m_registry, manifold_entity, manifold, rp);
             add_new_contact_point(contact_entity, manifold.body);

--- a/include/edyn/comp/center_of_mass.hpp
+++ b/include/edyn/comp/center_of_mass.hpp
@@ -5,6 +5,9 @@
 
 namespace edyn {
 
+/**
+ * @brief Center of mass offset from the rigid body's origin in object space.
+ */
 struct center_of_mass : public vector3 {
     center_of_mass & operator=(const vector3 &v) {
         vector3::operator=(v);

--- a/include/edyn/comp/center_of_mass.hpp
+++ b/include/edyn/comp/center_of_mass.hpp
@@ -1,0 +1,17 @@
+#ifndef EDYN_COMP_CENTER_OF_MASS_HPP
+#define EDYN_COMP_CENTER_OF_MASS_HPP
+
+#include "edyn/math/vector3.hpp"
+
+namespace edyn {
+
+struct center_of_mass : public vector3 {
+    center_of_mass & operator=(const vector3 &v) {
+        vector3::operator=(v);
+        return *this;
+    }
+};
+
+}
+
+#endif // EDYN_COMP_CENTER_OF_MASS_HPP

--- a/include/edyn/comp/shared_comp.hpp
+++ b/include/edyn/comp/shared_comp.hpp
@@ -9,6 +9,7 @@
 #include "edyn/comp/inertia.hpp"
 #include "edyn/comp/position.hpp"
 #include "edyn/comp/orientation.hpp"
+#include "edyn/comp/center_of_mass.hpp"
 #include "edyn/constraints/constraint.hpp"
 #include "edyn/constraints/constraint_impulse.hpp"
 #include "edyn/comp/tag.hpp"
@@ -49,6 +50,7 @@ static const auto shared_components = std::tuple_cat(std::tuple<
     contact_manifold,
     contact_point,
     continuous,
+    center_of_mass,
     dynamic_tag,
     kinematic_tag,
     static_tag,

--- a/include/edyn/parallel/island_coordinator.hpp
+++ b/include/edyn/parallel/island_coordinator.hpp
@@ -68,6 +68,8 @@ public:
 
     void set_solver_iterations(unsigned iterations);
 
+    void set_center_of_mass(entt::entity entity, const vector3 &com);
+
     // Call when settings have changed in the registry's context. It will
     // propagate changes to island workers.
     void settings_changed();

--- a/include/edyn/parallel/island_worker.hpp
+++ b/include/edyn/parallel/island_worker.hpp
@@ -93,6 +93,7 @@ public:
     void on_set_solver_iterations(const msg::set_solver_iterations &msg);
     void on_set_settings(const msg::set_settings &msg);
     void on_wake_up_island(const msg::wake_up_island &);
+    void on_set_com(const msg::set_com &);
 
     entity_graph::connected_components_t split();
 

--- a/include/edyn/parallel/message.hpp
+++ b/include/edyn/parallel/message.hpp
@@ -28,6 +28,11 @@ struct wake_up_island {};
 
 struct split_island {};
 
+struct set_com {
+    entt::entity entity;
+    vector3 com;
+};
+
 }
 
 #endif // EDYN_PARALLEL_MESSAGE_HPP

--- a/include/edyn/shapes/convex_mesh.hpp
+++ b/include/edyn/shapes/convex_mesh.hpp
@@ -42,8 +42,7 @@ struct convex_mesh {
      * is important because the moment of inertia of all shapes that can go
      * into a compound shape is calculated with respect to the center of mass
      * which is necessary for the parallel axis theorem to be applied when
-     * calculating the moment of inertia of a compound shape. Use a compound
-     * shape to shift the center of mass.
+     * calculating the moment of inertia of a compound shape.
      */
     void initialize();
 

--- a/include/edyn/util/aabb_util.hpp
+++ b/include/edyn/util/aabb_util.hpp
@@ -44,7 +44,7 @@ AABB point_cloud_aabb(const std::vector<vector3> &points);
  * @param orn Orientation of point cloud.
  * @return AABB of point set.
  */
-AABB point_cloud_aabb(const std::vector<vector3> &points, 
+AABB point_cloud_aabb(const std::vector<vector3> &points,
                       const vector3 &pos, const quaternion &orn);
 
 // Calculate AABB for all types of shapes.
@@ -61,7 +61,7 @@ AABB shape_aabb(const compound_shape &sh, const vector3 &pos, const quaternion &
 /**
  * @brief Visits the shape variant and calculates the the AABB.
  * @param var The shape variant.
- * @param pos Shape's position.
+ * @param pos Shape's origin.
  * @param orn Shape's orientation.
  * @return The AABB.
  */

--- a/include/edyn/util/collision_util.hpp
+++ b/include/edyn/util/collision_util.hpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <entt/entity/fwd.hpp>
 #include <entt/entity/entity.hpp>
-#include <entt/entity/utility.hpp>
 #include "edyn/comp/aabb.hpp"
 #include "edyn/comp/position.hpp"
 #include "edyn/comp/orientation.hpp"

--- a/include/edyn/util/rigidbody.hpp
+++ b/include/edyn/util/rigidbody.hpp
@@ -40,6 +40,7 @@ struct rigidbody_def {
     vector3 linvel {vector3_zero};
     vector3 angvel {vector3_zero};
 
+    // Center of mass offset from origin in object space.
     std::optional<vector3> center_of_mass;
 
     // Gravity acceleration. If not set, the default value from

--- a/include/edyn/util/rigidbody.hpp
+++ b/include/edyn/util/rigidbody.hpp
@@ -40,6 +40,8 @@ struct rigidbody_def {
     vector3 linvel {vector3_zero};
     vector3 angvel {vector3_zero};
 
+    std::optional<vector3> center_of_mass;
+
     // Gravity acceleration. If not set, the default value from
     // `edyn::get_gravity` will be assigned.
     std::optional<vector3> gravity;
@@ -145,6 +147,13 @@ void set_rigidbody_inertia(entt::registry &, entt::entity, const matrix3x3 &iner
  * @param friction The new friction coefficient.
  */
 void set_rigidbody_friction(entt::registry &, entt::entity, scalar);
+
+void set_center_of_mass(entt::registry &, entt::entity, const vector3 &com);
+
+void apply_center_of_mass(entt::registry &, entt::entity, const vector3 &com);
+
+vector3 get_rigidbody_origin(const entt::registry &, entt::entity);
+vector3 get_rigidbody_present_origin(const entt::registry &, entt::entity);
 
 }
 

--- a/include/edyn/util/rigidbody.hpp
+++ b/include/edyn/util/rigidbody.hpp
@@ -148,11 +148,38 @@ void set_rigidbody_inertia(entt::registry &, entt::entity, const matrix3x3 &iner
  */
 void set_rigidbody_friction(entt::registry &, entt::entity, scalar);
 
+/**
+ * @brief Offset the rigid body center of mass. The value represents an offset
+ * from the rigid body's origin in object space.
+ * @remark When the center of mass offset changes, the position and linear
+ * velocity change as well to reflect the value in the new location. This
+ * dependency makes it necessary to do these updates in the island worker or
+ * else the simulation will be slightly disturbed. For this reason, this call
+ * does not immediately update the center of mass.
+ * @param registry Data source.
+ * @param entity Rigid body entity.
+ * @param com Center of mass offset.
+ */
 void set_center_of_mass(entt::registry &, entt::entity, const vector3 &com);
 
 void apply_center_of_mass(entt::registry &, entt::entity, const vector3 &com);
 
+/**
+ * @brief Get location of rigid body's origin in world space. The position and
+ * origin will match if the center of mass offset is zero.
+ * @param registry Data source.
+ * @param entity Rigid body entity.
+ * @return Origin location in the world.
+ */
 vector3 get_rigidbody_origin(const entt::registry &, entt::entity);
+
+/**
+ * @brief Get interpolated location of rigid body's origin in world space for
+ * presentation.
+ * @param registry Data source.
+ * @param entity Rigid body entity.
+ * @return Origin location in the world for presentation.
+ */
 vector3 get_rigidbody_present_origin(const entt::registry &, entt::entity);
 
 }

--- a/src/edyn/collision/broadphase_worker.cpp
+++ b/src/edyn/collision/broadphase_worker.cpp
@@ -1,8 +1,6 @@
 #include "edyn/collision/broadphase_worker.hpp"
 #include "edyn/collision/tree_node.hpp"
 #include "edyn/comp/aabb.hpp"
-#include "edyn/comp/position.hpp"
-#include "edyn/comp/orientation.hpp"
 #include "edyn/comp/tree_resident.hpp"
 #include "edyn/collision/contact_manifold.hpp"
 #include "edyn/collision/tree_view.hpp"

--- a/src/edyn/collision/collide/collide_box_box.cpp
+++ b/src/edyn/collision/collide/collide_box_box.cpp
@@ -1,6 +1,7 @@
 #include "edyn/collision/collide.hpp"
 #include <algorithm>
 #include <numeric>
+#include "edyn/math/quaternion.hpp"
 #include "edyn/shapes/box_shape.hpp"
 #include "edyn/util/array.hpp"
 #include "edyn/math/matrix3x3.hpp"
@@ -238,13 +239,13 @@ void collide(const box_shape &shA, const box_shape &shB,
     } else if (featureA == box_feature::face && featureB == box_feature::vertex) {
         // Face A, Vertex B.
         auto pivotB = shB.get_vertex(feature_indexB);
-        auto pivotA = (posB + rotate(ornB, pivotB)) + sep_axis * distance;
+        auto pivotA = to_world_space(pivotB, posB, ornB) + sep_axis * distance;
         pivotA = to_object_space(pivotA, posA, ornA);
         result.add_point({pivotA, pivotB, sep_axis, distance});
     } else if (featureB == box_feature::face && featureA == box_feature::vertex) {
         // Face B, Vertex A.
         auto pivotA = shA.get_vertex(feature_indexA);
-        auto pivotB = (posA + rotate(ornA, pivotA)) - sep_axis * distance;
+        auto pivotB = to_world_space(pivotA, posA, ornA) - sep_axis * distance;
         pivotB = to_object_space(pivotB, posB, ornB);
         result.add_point({pivotA, pivotB, sep_axis, distance});
     }

--- a/src/edyn/collision/collide/collide_cylinder_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_cylinder.cpp
@@ -322,7 +322,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                     auto pivotB = vector3{pivotB_x,
                                         shB.radius * multipliers[i],
                                         shB.radius * multipliers[(i + 1) % 4]};
-                    auto pivotA = posB_in_A + rotate(ornB_in_A, pivotB);
+                    auto pivotA = to_world_space(pivotB, posB_in_A, ornB_in_A);
                     pivotA.x = shA.half_length * to_sign(feature_indexA == 0);
                     auto local_distance = get_local_distance(pivotA, pivotB);
                     result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
@@ -333,7 +333,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                     auto pivotA = vector3{pivotA_x,
                                         shA.radius * multipliers[i],
                                         shA.radius * multipliers[(i + 1) % 4]};
-                    auto pivotB = posA_in_B + rotate(ornA_in_B, pivotA);
+                    auto pivotB = to_world_space(pivotA, posA_in_B, ornA_in_B);
                     pivotB.x = shB.half_length * to_sign(feature_indexB == 0);
                     auto local_distance = get_local_distance(pivotA, pivotB);
                     result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});

--- a/src/edyn/collision/narrowphase.cpp
+++ b/src/edyn/collision/narrowphase.cpp
@@ -27,6 +27,7 @@ void narrowphase::update_async(job &completion_job) {
     auto manifold_view = m_registry->view<contact_manifold>();
     auto body_view = m_registry->view<AABB, shape_index, position, orientation>();
     auto tr_view = m_registry->view<position, orientation>();
+    auto com_view = m_registry->view<center_of_mass>();
     auto cp_view = m_registry->view<contact_point>();
     auto imp_view = m_registry->view<constraint_impulse>();
     auto shapes_views_tuple = get_tuple_of_shape_views(*m_registry);
@@ -38,15 +39,15 @@ void narrowphase::update_async(job &completion_job) {
     auto &dispatcher = job_dispatcher::global();
 
     parallel_for_async(dispatcher, size_t{0}, manifold_view.size(), size_t{1}, completion_job,
-            [this, body_view, tr_view, manifold_view, cp_view, imp_view, shapes_views_tuple] (size_t index) {
+            [this, body_view, tr_view, com_view, manifold_view, cp_view, imp_view, shapes_views_tuple] (size_t index) {
         auto entity = manifold_view[index];
         auto &manifold = manifold_view.get(entity);
         collision_result result;
         auto &construction_info = m_cp_construction_infos[index];
         auto &destruction_info = m_cp_destruction_infos[index];
 
-        detect_collision(manifold.body, result, body_view, shapes_views_tuple);
-        process_collision(entity, manifold, result, cp_view, imp_view, tr_view,
+        detect_collision(manifold.body, result, body_view, com_view, shapes_views_tuple);
+        process_collision(entity, manifold, result, cp_view, imp_view, tr_view, com_view,
                           [&construction_info] (const collision_result::collision_point &rp) {
             construction_info.point[construction_info.count++] = rp;
         }, [&destruction_info] (entt::entity contact_entity) {

--- a/src/edyn/collision/raycast.cpp
+++ b/src/edyn/collision/raycast.cpp
@@ -32,6 +32,7 @@ raycast_result raycast(entt::registry &registry, vector3 p0, vector3 p1) {
         auto orn = tr_view.get<orientation>(entity);
 
         if (com_view.contains(entity)) {
+            // Calculate origin using object space center of mass.
             auto &com = com_view.get(entity);
             pos = to_world_space(-com, pos, orn);
         }

--- a/src/edyn/collision/raycast.cpp
+++ b/src/edyn/collision/raycast.cpp
@@ -2,6 +2,7 @@
 #include "edyn/collision/tree_node.hpp"
 #include "edyn/comp/position.hpp"
 #include "edyn/comp/orientation.hpp"
+#include "edyn/comp/center_of_mass.hpp"
 #include "edyn/comp/shape_index.hpp"
 #include "edyn/collision/tree_view.hpp"
 #include "edyn/collision/broadphase_main.hpp"
@@ -18,6 +19,7 @@ namespace edyn {
 raycast_result raycast(entt::registry &registry, vector3 p0, vector3 p1) {
     auto index_view = registry.view<shape_index>();
     auto tr_view = registry.view<position, orientation>();
+    auto com_view = registry.view<center_of_mass>();
     auto tree_view_view = registry.view<tree_view>();
     auto shape_views_tuple = get_tuple_of_shape_views(registry);
 
@@ -28,6 +30,12 @@ raycast_result raycast(entt::registry &registry, vector3 p0, vector3 p1) {
         auto sh_idx = index_view.get(entity);
         auto pos = tr_view.get<position>(entity);
         auto orn = tr_view.get<orientation>(entity);
+
+        if (com_view.contains(entity)) {
+            auto &com = com_view.get(entity);
+            pos = to_world_space(-com, pos, orn);
+        }
+
         auto ctx = raycast_context{pos, orn, p0, p1};
 
         visit_shape(sh_idx, entity, shape_views_tuple, [&] (auto &&shape) {

--- a/src/edyn/constraints/contact_constraint.cpp
+++ b/src/edyn/constraints/contact_constraint.cpp
@@ -59,10 +59,10 @@ void prepare_constraints<contact_constraint>(entt::registry &registry, row_cache
         }
 
         auto normal = cp.normal;
-        auto pA = to_world_space(cp.pivotA, originA, ornA);
-        auto pB = to_world_space(cp.pivotB, originB, ornB);
-        auto rA = pA - posA;
-        auto rB = pB - posB;
+        auto pivotA = to_world_space(cp.pivotA, originA, ornA);
+        auto pivotB = to_world_space(cp.pivotB, originB, ornB);
+        auto rA = pivotA - posA;
+        auto rB = pivotB - posB;
         auto vA = linvelA + cross(angvelA, rA);
         auto vB = linvelB + cross(angvelB, rB);
         auto relvel = vA - vB;
@@ -86,7 +86,7 @@ void prepare_constraints<contact_constraint>(entt::registry &registry, row_cache
             normal_row.upper_limit = large_scalar;
         }
 
-        auto penetration = dot(pA - pB, normal);
+        auto penetration = dot(pivotA - pivotB, normal);
         auto pvel = penetration / dt;
 
         auto normal_options = constraint_row_options{};

--- a/src/edyn/constraints/distance_constraint.cpp
+++ b/src/edyn/constraints/distance_constraint.cpp
@@ -8,6 +8,7 @@
 #include "edyn/comp/angvel.hpp"
 #include "edyn/comp/delta_linvel.hpp"
 #include "edyn/comp/delta_angvel.hpp"
+#include "edyn/comp/center_of_mass.hpp"
 #include "edyn/constraints/constraint_impulse.hpp"
 #include "edyn/dynamics/row_cache.hpp"
 #include "edyn/util/constraint_util.hpp"
@@ -23,6 +24,7 @@ void prepare_constraints<distance_constraint>(entt::registry &registry, row_cach
                                    delta_linvel, delta_angvel>();
     auto con_view = registry.view<distance_constraint>();
     auto imp_view = registry.view<constraint_impulse>();
+    auto com_view = registry.view<center_of_mass>();
 
     con_view.each([&] (entt::entity entity, distance_constraint &con) {
         auto [posA, ornA, linvelA, angvelA, inv_mA, inv_IA, dvA, dwA] =
@@ -30,13 +32,28 @@ void prepare_constraints<distance_constraint>(entt::registry &registry, row_cach
         auto [posB, ornB, linvelB, angvelB, inv_mB, inv_IB, dvB, dwB] =
             body_view.get<position, orientation, linvel, angvel, mass_inv, inertia_world_inv, delta_linvel, delta_angvel>(con.body[1]);
 
-        auto rA = rotate(ornA, con.pivot[0]);
-        auto rB = rotate(ornB, con.pivot[1]);
+        auto originA = static_cast<vector3>(posA);
+        auto originB = static_cast<vector3>(posB);
 
-        auto d = posA + rA - posB - rB;
-        auto l2 = length_sqr(d);
+        if (com_view.contains(con.body[0])) {
+            auto &com = com_view.get(con.body[0]);
+            originA = to_world_space(-com, posA, ornA);
+        }
 
-        if (l2 <= EDYN_EPSILON) {
+        if (com_view.contains(con.body[1])) {
+            auto &com = com_view.get(con.body[1]);
+            originB = to_world_space(-com, posB, ornB);
+        }
+
+        auto pivotA = to_world_space(con.pivot[0], originA, ornA);
+        auto pivotB = to_world_space(con.pivot[1], originB, ornB);
+        auto rA = pivotA - posA;
+        auto rB = pivotB - posB;
+
+        auto d = pivotA - pivotB;
+        auto dist_sqr = length_sqr(d);
+
+        if (!(dist_sqr > EDYN_EPSILON)) {
             d = vector3_x;
         }
 
@@ -46,7 +63,7 @@ void prepare_constraints<distance_constraint>(entt::registry &registry, row_cach
         row.upper_limit =  large_scalar;
 
         auto options = constraint_row_options{};
-        options.error = scalar(0.5) * (l2 - con.distance * con.distance) / dt;
+        options.error = scalar(0.5) * (dist_sqr - con.distance * con.distance) / dt;
 
         row.inv_mA = inv_mA; row.inv_IA = inv_IA;
         row.inv_mB = inv_mB; row.inv_IB = inv_IB;

--- a/src/edyn/constraints/generic_constraint.cpp
+++ b/src/edyn/constraints/generic_constraint.cpp
@@ -11,6 +11,7 @@
 #include "edyn/comp/angvel.hpp"
 #include "edyn/comp/delta_linvel.hpp"
 #include "edyn/comp/delta_angvel.hpp"
+#include "edyn/comp/center_of_mass.hpp"
 #include "edyn/dynamics/row_cache.hpp"
 #include "edyn/util/constraint_util.hpp"
 #include <entt/entity/registry.hpp>
@@ -24,6 +25,7 @@ void prepare_constraints<generic_constraint>(entt::registry &registry, row_cache
                                    mass_inv, inertia_world_inv,
                                    delta_linvel, delta_angvel>();
     auto con_view = registry.view<generic_constraint, constraint_impulse>();
+    auto com_view = registry.view<center_of_mass>();
 
     con_view.each([&] (generic_constraint &con, constraint_impulse &imp) {
         auto [posA, ornA, linvelA, angvelA, inv_mA, inv_IA, dvA, dwA] =
@@ -31,12 +33,27 @@ void prepare_constraints<generic_constraint>(entt::registry &registry, row_cache
         auto [posB, ornB, linvelB, angvelB, inv_mB, inv_IB, dvB, dwB] =
             body_view.get<position, orientation, linvel, angvel, mass_inv, inertia_world_inv, delta_linvel, delta_angvel>(con.body[1]);
 
-        auto rA = rotate(ornA, con.pivot[0]);
-        auto rB = rotate(ornB, con.pivot[1]);
+        auto originA = static_cast<vector3>(posA);
+        auto originB = static_cast<vector3>(posB);
+
+        if (com_view.contains(con.body[0])) {
+            auto &com = com_view.get(con.body[0]);
+            originA = to_world_space(-com, posA, ornA);
+        }
+
+        if (com_view.contains(con.body[1])) {
+            auto &com = com_view.get(con.body[1]);
+            originB = to_world_space(-com, posB, ornB);
+        }
+
+        auto pivotA = to_world_space(con.pivot[0], originA, ornA);
+        auto pivotB = to_world_space(con.pivot[1], originB, ornB);
+        auto rA = pivotA - posA;
+        auto rB = pivotB - posB;
 
         auto rA_skew = skew_matrix(rA);
         auto rB_skew = skew_matrix(rB);
-        const auto d = posA + rA - posB - rB;
+        auto d = pivotA - pivotB;
         constexpr auto I = matrix3x3_identity;
 
         // Linear.

--- a/src/edyn/constraints/point_constraint.cpp
+++ b/src/edyn/constraints/point_constraint.cpp
@@ -10,6 +10,7 @@
 #include "edyn/comp/angvel.hpp"
 #include "edyn/comp/delta_linvel.hpp"
 #include "edyn/comp/delta_angvel.hpp"
+#include "edyn/comp/center_of_mass.hpp"
 #include "edyn/dynamics/row_cache.hpp"
 #include "edyn/util/constraint_util.hpp"
 #include <entt/entity/registry.hpp>
@@ -23,6 +24,7 @@ void prepare_constraints<point_constraint>(entt::registry &registry, row_cache &
                                    mass_inv, inertia_world_inv,
                                    delta_linvel, delta_angvel>();
     auto con_view = registry.view<point_constraint, constraint_impulse>();
+    auto com_view = registry.view<center_of_mass>();
 
     con_view.each([&] (point_constraint &con, constraint_impulse& imp) {
         auto [posA, ornA, linvelA, angvelA, inv_mA, inv_IA, dvA, dwA] =
@@ -30,11 +32,23 @@ void prepare_constraints<point_constraint>(entt::registry &registry, row_cache &
         auto [posB, ornB, linvelB, angvelB, inv_mB, inv_IB, dvB, dwB] =
             body_view.get<position, orientation, linvel, angvel, mass_inv, inertia_world_inv, delta_linvel, delta_angvel>(con.body[1]);
 
-        auto rA = con.pivot[0];
-        auto rB = con.pivot[1];
+        auto originA = static_cast<vector3>(posA);
+        auto originB = static_cast<vector3>(posB);
 
-        rA = rotate(ornA, rA);
-        rB = rotate(ornB, rB);
+        if (com_view.contains(con.body[0])) {
+            auto &com = com_view.get(con.body[0]);
+            originA = to_world_space(-com, posA, ornA);
+        }
+
+        if (com_view.contains(con.body[1])) {
+            auto &com = com_view.get(con.body[1]);
+            originB = to_world_space(-com, posB, ornB);
+        }
+
+        auto pivotA = to_world_space(con.pivot[0], originA, ornA);
+        auto pivotB = to_world_space(con.pivot[1], originB, ornB);
+        auto rA = pivotA - posA;
+        auto rB = pivotB - posB;
 
         auto rA_skew = skew_matrix(rA);
         auto rB_skew = skew_matrix(rB);
@@ -53,7 +67,7 @@ void prepare_constraints<point_constraint>(entt::registry &registry, row_cache &
             row.impulse = imp.values[i];
 
             auto options = constraint_row_options{};
-            options.error = (posA[i] + rA[i] - posB[i] - rB[i]) / dt;
+            options.error = (pivotA[i] - pivotB[i]) / dt;
 
             prepare_row(row, options, linvelA, linvelB, angvelA, angvelB);
             warm_start(row);

--- a/src/edyn/parallel/island_coordinator.cpp
+++ b/src/edyn/parallel/island_coordinator.cpp
@@ -1,6 +1,7 @@
 #include "edyn/parallel/island_coordinator.hpp"
 #include "edyn/collision/contact_manifold.hpp"
 #include "edyn/collision/contact_point.hpp"
+#include "edyn/comp/center_of_mass.hpp"
 #include "edyn/comp/inertia.hpp"
 #include "edyn/comp/island.hpp"
 #include "edyn/comp/present_orientation.hpp"
@@ -371,6 +372,7 @@ void island_coordinator::insert_to_island(entt::entity island_entity,
     auto vel_view = m_registry->view<linvel, angvel>();
     auto mass_view = m_registry->view<mass, mass_inv, inertia, inertia_inv, inertia_world_inv>();
     auto gravity_view = m_registry->view<gravity>();
+    auto com_view = m_registry->view<center_of_mass>();
     auto material_view = m_registry->view<material>();
     auto continuous_view = m_registry->view<continuous>();
     auto procedural_view = m_registry->view<procedural_tag>();
@@ -422,6 +424,10 @@ void island_coordinator::insert_to_island(entt::entity island_entity,
 
             if (gravity_view.contains(entity)) {
                 ctx->m_delta_builder->created(entity, gravity_view.get(entity));
+            }
+
+            if (com_view.contains(entity)) {
+                ctx->m_delta_builder->created(entity, com_view.get(entity));
             }
 
             if (material_view.contains(entity)) {
@@ -944,6 +950,12 @@ void island_coordinator::settings_changed() {
         auto &ctx = pair.second;
         ctx->send<msg::set_settings>(settings);
     }
+}
+
+void island_coordinator::set_center_of_mass(entt::entity entity, const vector3 &com) {
+    auto &resident = m_registry->get<island_resident>(entity);
+    auto &ctx = m_island_ctx_map.at(resident.island_entity);
+    ctx->send<msg::set_com>(entity, com);
 }
 
 }

--- a/src/edyn/parallel/island_worker.cpp
+++ b/src/edyn/parallel/island_worker.cpp
@@ -20,6 +20,7 @@
 #include "edyn/math/constants.hpp"
 #include "edyn/collision/tree_view.hpp"
 #include "edyn/util/aabb_util.hpp"
+#include "edyn/util/rigidbody.hpp"
 #include "edyn/util/vector.hpp"
 #include "edyn/util/collision_util.hpp"
 #include "edyn/context/settings.hpp"
@@ -95,6 +96,7 @@ void island_worker::init() {
     m_message_queue.sink<msg::set_fixed_dt>().connect<&island_worker::on_set_fixed_dt>(*this);
     m_message_queue.sink<msg::set_solver_iterations>().connect<&island_worker::on_set_solver_iterations>(*this);
     m_message_queue.sink<msg::wake_up_island>().connect<&island_worker::on_wake_up_island>(*this);
+    m_message_queue.sink<msg::set_com>().connect<&island_worker::on_set_com>(*this);
 
     process_messages();
 
@@ -838,6 +840,11 @@ void island_worker::on_set_solver_iterations(const msg::set_solver_iterations &m
 
 void island_worker::on_set_settings(const msg::set_settings &msg) {
     m_registry.ctx<settings>() = msg.settings;
+}
+
+void island_worker::on_set_com(const msg::set_com &msg) {
+    auto entity = m_entity_map.remloc(msg.entity);
+    apply_center_of_mass(m_registry, entity, msg.com);
 }
 
 entity_graph::connected_components_t island_worker::split() {

--- a/src/edyn/shapes/box_shape.cpp
+++ b/src/edyn/shapes/box_shape.cpp
@@ -1,5 +1,6 @@
 #include "edyn/shapes/box_shape.hpp"
 #include "edyn/math/matrix3x3.hpp"
+#include "edyn/math/quaternion.hpp"
 #include "edyn/util/shape_util.hpp"
 #include "edyn/math/vector2_3_util.hpp"
 #include <cstdint>
@@ -127,7 +128,7 @@ vector3 box_shape::get_vertex(size_t vertex_idx) const {
 }
 
 vector3 box_shape::get_vertex(size_t vertex_idx, const vector3 &pos, const quaternion &orn) const {
-    return pos + rotate(orn, get_vertex(vertex_idx));
+    return to_world_space(get_vertex(vertex_idx), pos, orn);
 }
 
 std::array<vector3, 2> box_shape::get_edge(size_t edge_idx) const {
@@ -141,8 +142,8 @@ std::array<vector3, 2> box_shape::get_edge(size_t edge_idx) const {
 std::array<vector3, 2> box_shape::get_edge(size_t edge_idx, const vector3 &pos, const quaternion &orn) const {
     auto edge_vertices = get_edge(edge_idx);
     return {
-        pos + rotate(orn, edge_vertices[0]),
-        pos + rotate(orn, edge_vertices[1])
+        to_world_space(edge_vertices[0], pos, orn),
+        to_world_space(edge_vertices[1], pos, orn)
     };
 }
 
@@ -159,10 +160,10 @@ std::array<vector3, 4> box_shape::get_face(size_t face_idx) const {
 std::array<vector3, 4> box_shape::get_face(size_t face_idx, const vector3 &pos, const quaternion &orn) const {
     auto face_vertices = get_face(face_idx);
     return {
-        pos + rotate(orn, face_vertices[0]),
-        pos + rotate(orn, face_vertices[1]),
-        pos + rotate(orn, face_vertices[2]),
-        pos + rotate(orn, face_vertices[3])
+        to_world_space(face_vertices[0], pos, orn),
+        to_world_space(face_vertices[1], pos, orn),
+        to_world_space(face_vertices[2], pos, orn),
+        to_world_space(face_vertices[3], pos, orn)
     };
 }
 

--- a/src/edyn/util/collision_util.cpp
+++ b/src/edyn/util/collision_util.cpp
@@ -1,5 +1,6 @@
 #include "edyn/util/collision_util.hpp"
 #include "edyn/comp/material.hpp"
+#include "edyn/math/quaternion.hpp"
 #include "edyn/util/constraint_util.hpp"
 #include "edyn/constraints/contact_constraint.hpp"
 #include "edyn/collision/collide.hpp"
@@ -11,12 +12,26 @@ namespace edyn {
 void update_contact_distances(entt::registry &registry) {
     auto cp_view = registry.view<contact_point>();
     auto tr_view = registry.view<position, orientation>();
+    auto com_view = registry.view<center_of_mass>();
 
     cp_view.each([&] (contact_point &cp) {
         auto [posA, ornA] = tr_view.get<position, orientation>(cp.body[0]);
         auto [posB, ornB] = tr_view.get<position, orientation>(cp.body[1]);
-        auto pivotA_world = posA + rotate(ornA, cp.pivotA);
-        auto pivotB_world = posB + rotate(ornB, cp.pivotB);
+        auto originA = static_cast<vector3>(posA);
+        auto originB = static_cast<vector3>(posB);
+
+        if (com_view.contains(cp.body[0])) {
+            auto &com = com_view.get(cp.body[0]);
+            originA = to_world_space(-com, posA, ornA);
+        }
+
+        if (com_view.contains(cp.body[1])) {
+            auto &com = com_view.get(cp.body[1]);
+            originB = to_world_space(-com, posB, ornB);
+        }
+
+        auto pivotA_world = to_world_space(cp.pivotA, originA, ornA);
+        auto pivotB_world = to_world_space(cp.pivotB, originB, ornB);
         cp.distance = dot(cp.normal, pivotA_world - pivotB_world);
     });
 }
@@ -122,8 +137,8 @@ bool maybe_remove_point(contact_manifold &manifold, const contact_point &cp, siz
     constexpr auto threshold_sqr = threshold * threshold;
 
     // Remove separating contact points.
-    auto pA = posA + rotate(ornA, cp.pivotA);
-    auto pB = posB + rotate(ornB, cp.pivotB);
+    auto pA = to_world_space(cp.pivotA, posA, ornA);
+    auto pB = to_world_space(cp.pivotB, posB, ornB);
     auto n = cp.normal;
     auto d = pA - pB;
     auto normal_dist = dot(d, n);
@@ -150,7 +165,8 @@ void destroy_contact_point(entt::registry &registry, entt::entity manifold_entit
 }
 
 void detect_collision(std::array<entt::entity, 2> body, collision_result &result,
-                      const detect_collision_body_view_t &body_view, const tuple_of_shape_views_t &views_tuple) {
+                      const detect_collision_body_view_t &body_view, const com_view_t &com_view,
+                      const tuple_of_shape_views_t &views_tuple) {
     auto [aabbA, posA, ornA] = body_view.get<AABB, position, orientation>(body[0]);
     auto [aabbB, posB, ornB] = body_view.get<AABB, position, orientation>(body[1]);
     const auto offset = vector3_one * -contact_breaking_threshold;
@@ -160,9 +176,22 @@ void detect_collision(std::array<entt::entity, 2> body, collision_result &result
     // than `manifold.separation_threshold` which is greater than the
     // contact breaking threshold.
     if (intersect(aabbA.inset(offset), aabbB)) {
+        auto originA = static_cast<vector3>(posA);
+        auto originB = static_cast<vector3>(posB);
+
+        if (com_view.contains(body[0])) {
+            auto &com = com_view.get(body[0]);
+            originA = to_world_space(-com, posA, ornA);
+        }
+
+        if (com_view.contains(body[1])) {
+            auto &com = com_view.get(body[1]);
+            originB = to_world_space(-com, posB, ornB);
+        }
+
         auto shape_indexA = body_view.get<shape_index>(body[0]);
         auto shape_indexB = body_view.get<shape_index>(body[1]);
-        auto ctx = collision_context{posA, ornA, aabbA, posB, ornB, aabbB, contact_breaking_threshold};
+        auto ctx = collision_context{originA, ornA, aabbA, originB, ornB, aabbB, contact_breaking_threshold};
 
         visit_shape(shape_indexA, body[0], views_tuple, [&] (auto &&shA) {
             visit_shape(shape_indexB, body[1], views_tuple, [&] (auto &&shB) {

--- a/src/edyn/util/moment_of_inertia.cpp
+++ b/src/edyn/util/moment_of_inertia.cpp
@@ -27,8 +27,8 @@ vector3 moment_of_inertia_solid_capsule(scalar mass, scalar len, scalar radius) 
     auto sph_inertia = moment_of_inertia_solid_sphere(sph_mass, radius);
 
     auto xx = sph_inertia + cyl_inertia.x;
-    auto yy_zz = sph_mass * (scalar(0.4) * radius * radius + 
-                             scalar(0.375) * radius * len + 
+    auto yy_zz = sph_mass * (scalar(0.4) * radius * radius +
+                             scalar(0.375) * radius * len +
                              scalar(0.25 * len * len)) + cyl_inertia.y;
     return {xx, yy_zz, yy_zz};
 }
@@ -49,7 +49,7 @@ vector3 moment_of_inertia_solid_cylinder(scalar mass, scalar len, scalar radius)
     return {xx, yy_zz, yy_zz};
 }
 
-vector3 moment_of_inertia_hollow_cylinder(scalar mass, scalar len, 
+vector3 moment_of_inertia_hollow_cylinder(scalar mass, scalar len,
                                           scalar inner_radius, scalar outer_radius) {
     auto rr = inner_radius * inner_radius + outer_radius * outer_radius;
     auto xx = scalar(0.5) * mass * rr;
@@ -58,10 +58,10 @@ vector3 moment_of_inertia_hollow_cylinder(scalar mass, scalar len,
 }
 
 matrix3x3 moment_of_inertia_polyhedron(scalar mass,
-                                       const std::vector<vector3> &vertices, 
+                                       const std::vector<vector3> &vertices,
                                        const std::vector<uint16_t> &indices,
                                        const std::vector<uint16_t> &faces) {
-    // Reference: 
+    // Reference:
     // https://github.com/erich666/jgt-code/blob/master/Volume_11/Number_2/Kallay2006/Moment_of_Inertia.cpp
     scalar volume = 0;
     scalar xx = 0;

--- a/src/edyn/util/rigidbody.cpp
+++ b/src/edyn/util/rigidbody.cpp
@@ -32,6 +32,8 @@ void rigidbody_def::update_inertia() {
     inertia = moment_of_inertia(*shape, mass);
 
     if (center_of_mass) {
+        // Use parallel-axis theorem to calculate moment of inertia along
+        // axes away from the center of mass.
         auto d = skew_matrix(*center_of_mass);
         inertia += transpose(d) * d * mass;
     }
@@ -264,6 +266,8 @@ void apply_center_of_mass(entt::registry &registry, entt::entity entity, const v
         com_old = com_view.get(entity);
     }
 
+    // Position and linear velocity must change when center of mass shifts,
+    // since they're stored with respect to the center of mass.
     auto origin = to_world_space(-com_old, pos, orn);
     auto com_world = to_world_space(com, origin, orn);
     linvel += cross(angvel, com_world - pos);

--- a/src/edyn/util/rigidbody.cpp
+++ b/src/edyn/util/rigidbody.cpp
@@ -1,5 +1,8 @@
 #include <entt/entity/registry.hpp>
+#include "edyn/comp/center_of_mass.hpp"
+#include "edyn/comp/dirty.hpp"
 #include "edyn/math/matrix3x3.hpp"
+#include "edyn/math/vector3.hpp"
 #include "edyn/util/rigidbody.hpp"
 #include "edyn/comp/tag.hpp"
 #include "edyn/comp/aabb.hpp"
@@ -27,6 +30,11 @@ namespace edyn {
 
 void rigidbody_def::update_inertia() {
     inertia = moment_of_inertia(*shape, mass);
+
+    if (center_of_mass) {
+        auto d = skew_matrix(*center_of_mass);
+        inertia += transpose(d) * d * mass;
+    }
 }
 
 void make_rigidbody(entt::entity entity, entt::registry &registry, const rigidbody_def &def) {
@@ -56,6 +64,10 @@ void make_rigidbody(entt::entity entity, entt::registry &registry, const rigidbo
     } else {
         registry.emplace<linvel>(entity, def.linvel);
         registry.emplace<angvel>(entity, def.angvel);
+    }
+
+    if (def.center_of_mass) {
+        apply_center_of_mass(registry, entity, *def.center_of_mass);
     }
 
     auto gravity = def.gravity ? *def.gravity : registry.ctx<settings>().gravity;
@@ -233,6 +245,64 @@ void set_rigidbody_friction(entt::registry &registry, entt::entity entity, scala
             refresh<contact_point>(registry, manifold.point[i]);
         }
     });
+}
+
+void set_center_of_mass(entt::registry &registry, entt::entity entity, const vector3 &com) {
+    auto &coordinator = registry.ctx<island_coordinator>();
+    coordinator.set_center_of_mass(entity, com);
+}
+
+void apply_center_of_mass(entt::registry &registry, entt::entity entity, const vector3 &com) {
+    auto body_view = registry.view<position, orientation, linvel, angvel>();
+    auto com_view = registry.view<center_of_mass>();
+
+    auto [pos, orn, linvel, angvel] = body_view.get<position, orientation, edyn::linvel, edyn::angvel>(entity);
+    auto com_old = vector3_zero;
+    auto has_com = com_view.contains(entity);
+
+    if (has_com) {
+        com_old = com_view.get(entity);
+    }
+
+    auto origin = to_world_space(-com_old, pos, orn);
+    auto com_world = to_world_space(com, origin, orn);
+    linvel += cross(angvel, com_world - pos);
+    pos = com_world;
+
+    auto &dirty = registry.get_or_emplace<edyn::dirty>(entity);
+
+    if (com != vector3_zero) {
+        if (has_com) {
+            registry.replace<center_of_mass>(entity, com);
+            dirty.updated<center_of_mass>();
+        } else {
+            registry.emplace<center_of_mass>(entity, com);
+            dirty.created<center_of_mass>();
+        }
+    } else if (has_com) {
+        registry.remove<center_of_mass>(entity);
+        dirty.destroyed<center_of_mass>();
+    }
+}
+
+vector3 get_rigidbody_origin(const entt::registry &registry, entt::entity entity) {
+    if (!registry.has<center_of_mass>(entity)) {
+        return registry.get<position>(entity);
+    }
+
+    auto [com, pos, orn] = registry.get<center_of_mass, position, orientation>(entity);
+    auto origin = to_world_space(-com, pos, orn);
+    return origin;
+}
+
+vector3 get_rigidbody_present_origin(const entt::registry &registry, entt::entity entity) {
+    if (!registry.has<center_of_mass>(entity)) {
+        return registry.get<present_position>(entity);
+    }
+
+    auto [com, pos, orn] = registry.get<center_of_mass, present_position, present_orientation>(entity);
+    auto origin = to_world_space(-com, pos, orn);
+    return origin;
 }
 
 }

--- a/src/edyn/util/rigidbody.cpp
+++ b/src/edyn/util/rigidbody.cpp
@@ -72,7 +72,7 @@ void make_rigidbody(entt::entity entity, entt::registry &registry, const rigidbo
         apply_center_of_mass(registry, entity, *def.center_of_mass);
     }
 
-    auto gravity = def.gravity ? *def.gravity : registry.ctx<settings>().gravity;
+    auto gravity = def.gravity ? *def.gravity : get_gravity(registry);
 
     if (gravity != vector3_zero && def.kind == rigidbody_kind::rb_dynamic) {
         registry.emplace<edyn::gravity>(entity, gravity);


### PR DESCRIPTION
Allow the center of mass of a rigid body to be changed. The position of a rigid body continues to be the location of its center of mass. If the center of mass offset is non-zero, the origin of the rigid body will not coincide. All constraint pivots are set in object space where the origin is the center, which allows the center of mass to change without affecting the constraint pivots.