### PR TITLE
Island updates

### DIFF
--- a/include/edyn/parallel/entity_component_container.hpp
+++ b/include/edyn/parallel/entity_component_container.hpp
@@ -4,7 +4,7 @@
 
 #include <vector>
 #include <utility>
-#include <entt/entity/fwd.hpp>
+#include <entt/entity/registry.hpp>
 #include "edyn/parallel/merge/merge_component.hpp"
 #include "edyn/parallel/merge/merge_contact_point.hpp"
 #include "edyn/parallel/merge/merge_contact_manifold.hpp"

--- a/include/edyn/parallel/entity_graph.hpp
+++ b/include/edyn/parallel/entity_graph.hpp
@@ -63,6 +63,7 @@ public:
 
     index_type insert_edge(entt::entity entity, index_type node_index0, index_type node_index1);
     void remove_edge(index_type edge_index);
+    void remove_all_edges(index_type node_index);
     entt::entity edge_entity(index_type edge_index) const;
     bool has_adjacency(index_type node_index0, index_type node_index1) const;
     entity_pair edge_node_entities(index_type edge_index) const;
@@ -165,6 +166,7 @@ void entity_graph::visit_neighbors(index_type node_index, Func func) const {
         auto &neighbor = m_nodes[adj.node_index];
         EDYN_ASSERT(neighbor.entity != entt::null);
         func(neighbor.entity);
+        EDYN_ASSERT(adj.next != adj_index);
         adj_index = adj.next;
     }
 }
@@ -175,6 +177,7 @@ void entity_graph::visit_edges(index_type node_index0, index_type node_index1, F
     EDYN_ASSERT(node_index1 < m_nodes.size());
 
     auto adj_index = m_nodes[node_index0].adjacency_index;
+
     while (adj_index != null_index) {
         auto &adj = m_adjacencies[adj_index];
         if (adj.node_index == node_index1) {
@@ -183,6 +186,7 @@ void entity_graph::visit_edges(index_type node_index0, index_type node_index1, F
                 auto &edge = m_edges[edge_index];
                 EDYN_ASSERT(edge.entity != entt::null);
                 func(edge.entity);
+                EDYN_ASSERT(edge.next != edge_index);
                 edge_index = edge.next;
             }
             break;
@@ -196,6 +200,7 @@ void entity_graph::visit_edges(index_type node_index, Func func) const {
     EDYN_ASSERT(node_index < m_nodes.size());
 
     auto adj_index = m_nodes[node_index].adjacency_index;
+
     while (adj_index != null_index) {
         auto &adj = m_adjacencies[adj_index];
         auto edge_index = adj.edge_index;
@@ -204,6 +209,7 @@ void entity_graph::visit_edges(index_type node_index, Func func) const {
             auto &edge = m_edges[edge_index];
             EDYN_ASSERT(edge.entity != entt::null);
             func(edge.entity);
+            EDYN_ASSERT(edge.next != edge_index);
             edge_index = edge.next;
         }
 

--- a/include/edyn/parallel/island_coordinator.hpp
+++ b/include/edyn/parallel/island_coordinator.hpp
@@ -25,7 +25,12 @@ class island_coordinator final {
 
     void init_new_nodes_and_edges();
     void init_new_non_procedural_node(entt::entity);
-    entt::entity create_island(double timestamp, bool sleeping);
+    entt::entity create_island(double timestamp, bool sleeping,
+                               const std::vector<entt::entity> &nodes,
+                               const std::vector<entt::entity> &edges);
+    void insert_to_island(island_worker_context &ctx,
+                          const std::vector<entt::entity> &nodes,
+                          const std::vector<entt::entity> &edges);
     void insert_to_island(entt::entity island_entity,
                           const std::vector<entt::entity> &nodes,
                           const std::vector<entt::entity> &edges);

--- a/include/edyn/parallel/island_worker.hpp
+++ b/include/edyn/parallel/island_worker.hpp
@@ -41,6 +41,7 @@ class island_worker final {
         finish_step
     };
 
+    void init();
     void process_messages();
     bool should_step();
     void begin_step();
@@ -69,8 +70,6 @@ public:
     island_worker(entt::entity island_entity, const settings &, message_queue_in_out message_queue);
 
     ~island_worker();
-
-    void init();
 
     entt::entity island_entity() const {
         return m_island_entity;

--- a/include/edyn/parallel/island_worker.hpp
+++ b/include/edyn/parallel/island_worker.hpp
@@ -41,7 +41,6 @@ class island_worker final {
         finish_step
     };
 
-    void init();
     void process_messages();
     bool should_step();
     void begin_step();
@@ -70,6 +69,8 @@ public:
     island_worker(entt::entity island_entity, const settings &, message_queue_in_out message_queue);
 
     ~island_worker();
+
+    void init();
 
     entt::entity island_entity() const {
         return m_island_entity;
@@ -121,6 +122,7 @@ private:
 
     std::unique_ptr<island_delta_builder> m_delta_builder;
     bool m_importing_delta;
+    bool m_destroying_node;
     bool m_topology_changed;
     bool m_pending_split_calculation;
     double m_calculate_split_delay;

--- a/include/edyn/parallel/island_worker_context.hpp
+++ b/include/edyn/parallel/island_worker_context.hpp
@@ -43,10 +43,6 @@ public:
                 message_queue_in_out message_queue);
     ~island_worker_context();
 
-    void init() {
-        m_worker->init();
-    }
-
     /**
      * Returns whether the current delta doesn't contain any changes.
      */

--- a/include/edyn/parallel/island_worker_context.hpp
+++ b/include/edyn/parallel/island_worker_context.hpp
@@ -43,6 +43,10 @@ public:
                 message_queue_in_out message_queue);
     ~island_worker_context();
 
+    void init() {
+        m_worker->init();
+    }
+
     /**
      * Returns whether the current delta doesn't contain any changes.
      */
@@ -91,6 +95,10 @@ public:
 
     auto split_island_sink() {
         return entt::sink {m_split_island_signal};
+    }
+
+    auto island_entity() const {
+        return m_island_entity;
     }
 
     /**

--- a/src/edyn/parallel/island_coordinator.cpp
+++ b/src/edyn/parallel/island_coordinator.cpp
@@ -72,7 +72,18 @@ void island_coordinator::on_construct_graph_edge(entt::registry &registry, entt:
 
 void island_coordinator::on_destroy_graph_node(entt::registry &registry, entt::entity entity) {
     auto &node = registry.get<graph_node>(entity);
-    registry.ctx<entity_graph>().remove_node(node.node_index);
+    auto &graph = registry.ctx<entity_graph>();
+
+    registry.on_destroy<graph_edge>().disconnect<&island_coordinator::on_destroy_graph_edge>(*this);
+
+    graph.visit_edges(node.node_index, [&] (entt::entity edge_entity) {
+        registry.destroy(edge_entity);
+    });
+
+    registry.on_destroy<graph_edge>().connect<&island_coordinator::on_destroy_graph_edge>(*this);
+
+    graph.remove_all_edges(node.node_index);
+    graph.remove_node(node.node_index);
 }
 
 void island_coordinator::on_destroy_graph_edge(entt::registry &registry, entt::entity entity) {
@@ -242,8 +253,7 @@ void island_coordinator::init_new_nodes_and_edges() {
         },
         [&] () { // connectedComponentFunc
             if (island_entities.empty()) {
-                auto island_entity = create_island(m_timestamp, false);
-                insert_to_island(island_entity, connected_nodes, connected_edges);
+                create_island(m_timestamp, false, connected_nodes, connected_edges);
             } else if (island_entities.size() == 1) {
                 auto island_entity = *island_entities.begin();
                 insert_to_island(island_entity, connected_nodes, connected_edges);
@@ -283,7 +293,9 @@ void island_coordinator::init_new_non_procedural_node(entt::entity node_entity) 
     });
 }
 
-entt::entity island_coordinator::create_island(double timestamp, bool sleeping) {
+entt::entity island_coordinator::create_island(double timestamp, bool sleeping,
+                                               const std::vector<entt::entity> &nodes,
+                                               const std::vector<entt::entity> &edges) {
     auto island_entity = m_registry->create();
     m_registry->emplace<island>(island_entity);
     auto &isle_time = m_registry->emplace<island_timestamp>(island_entity);
@@ -300,9 +312,12 @@ entt::entity island_coordinator::create_island(double timestamp, bool sleeping) 
     auto &settings = m_registry->ctx<edyn::settings>();
     auto *worker = new island_worker(island_entity, settings,
                                      message_queue_in_out(main_queue_input, isle_queue_output));
-    auto ctx = std::make_unique<island_worker_context>(island_entity, worker,
-                                                       (*settings.make_island_delta_builder)(),
-                                                       message_queue_in_out(isle_queue_input, main_queue_output));
+
+    m_island_ctx_map[island_entity] = std::make_unique<island_worker_context>(
+        island_entity, worker, (*settings.make_island_delta_builder)(),
+        message_queue_in_out(isle_queue_input, main_queue_output));
+
+    auto &ctx = m_island_ctx_map[island_entity];
 
     // Insert the first entity mapping between the remote island entity and
     // the local island entity.
@@ -314,17 +329,19 @@ entt::entity island_coordinator::create_island(double timestamp, bool sleeping) 
 
     // Send over a delta containing this island entity to the island worker
     // before it even starts.
-    auto builder = (*settings.make_island_delta_builder)();
-    builder->created(island_entity, isle_time);
+    ctx->m_delta_builder->created(island_entity, isle_time);
 
     if (sleeping) {
         m_registry->emplace<sleeping_tag>(island_entity);
-        builder->created(island_entity, sleeping_tag{});
+        ctx->m_delta_builder->created(island_entity, sleeping_tag{});
     }
 
-    ctx->send<island_delta>(builder->finish());
+    insert_to_island(*ctx, nodes, edges);
 
-    m_island_ctx_map.emplace(island_entity, std::move(ctx));
+    ctx->send<island_delta>(ctx->m_delta_builder->finish());
+
+    ctx->init();
+    ctx->read_messages();
 
     return island_entity;
 }
@@ -332,10 +349,16 @@ entt::entity island_coordinator::create_island(double timestamp, bool sleeping) 
 void island_coordinator::insert_to_island(entt::entity island_entity,
                                           const std::vector<entt::entity> &nodes,
                                           const std::vector<entt::entity> &edges) {
-
     auto &ctx = m_island_ctx_map.at(island_entity);
-    ctx->m_nodes.insert(nodes.begin(), nodes.end());
-    ctx->m_edges.insert(edges.begin(), edges.end());
+    insert_to_island(*ctx, nodes, edges);
+}
+
+void island_coordinator::insert_to_island(island_worker_context &ctx,
+                                          const std::vector<entt::entity> &nodes,
+                                          const std::vector<entt::entity> &edges) {
+
+    ctx.m_nodes.insert(nodes.begin(), nodes.end());
+    ctx.m_edges.insert(edges.begin(), edges.end());
 
     auto resident_view = m_registry->view<island_resident>();
     auto multi_resident_view = m_registry->view<multi_island_resident>();
@@ -357,27 +380,28 @@ void island_coordinator::insert_to_island(entt::entity island_entity,
         }
     }
 
-    ctx->m_delta_builder->reserve_created(nodes.size() + edges.size() + total_num_points);
-    ctx->m_delta_builder->reserve_created<contact_constraint>(total_num_points);
-    ctx->m_delta_builder->reserve_created<contact_point>(total_num_points);
-    ctx->m_delta_builder->reserve_created<constraint_impulse>(total_num_constraints);
-    ctx->m_delta_builder->reserve_created<position, orientation, linvel, angvel, continuous>(nodes.size());
-    ctx->m_delta_builder->reserve_created<mass, mass_inv, inertia, inertia_inv, inertia_world_inv>(nodes.size());
+    ctx.m_delta_builder->reserve_created(nodes.size() + edges.size() + total_num_points);
+    ctx.m_delta_builder->reserve_created<contact_constraint>(total_num_points);
+    ctx.m_delta_builder->reserve_created<contact_point>(total_num_points);
+    ctx.m_delta_builder->reserve_created<constraint_impulse>(total_num_constraints);
+    ctx.m_delta_builder->reserve_created<position, orientation, linvel, angvel, continuous>(nodes.size());
+    ctx.m_delta_builder->reserve_created<mass, mass_inv, inertia, inertia_inv, inertia_world_inv>(nodes.size());
+    auto island_entity = ctx.island_entity();
 
     for (auto entity : nodes) {
         if (procedural_view.contains(entity)) {
             auto &resident = resident_view.get(entity);
             resident.island_entity = island_entity;
-            ctx->m_delta_builder->created(entity);
-            ctx->m_delta_builder->created_all(entity, *m_registry);
+            ctx.m_delta_builder->created(entity);
+            ctx.m_delta_builder->created_all(entity, *m_registry);
         } else {
             auto &resident = multi_resident_view.get(entity);
 
             if (resident.island_entities.count(island_entity) == 0) {
                 // Non-procedural entity is not yet in this island, thus create it.
                 resident.island_entities.insert(island_entity);
-                ctx->m_delta_builder->created(entity);
-                ctx->m_delta_builder->created_all(entity, *m_registry);
+                ctx.m_delta_builder->created(entity);
+                ctx.m_delta_builder->created_all(entity, *m_registry);
             }
         }
     }
@@ -388,8 +412,8 @@ void island_coordinator::insert_to_island(entt::entity island_entity,
         auto &resident = resident_view.get(entity);
         resident.island_entity = island_entity;
         // Add new entities to the delta builder.
-        ctx->m_delta_builder->created(entity);
-        ctx->m_delta_builder->created_all(entity, *m_registry);
+        ctx.m_delta_builder->created(entity);
+        ctx.m_delta_builder->created_all(entity, *m_registry);
 
         // Add child entities.
         if (manifold_view.contains(entity)) {
@@ -402,8 +426,8 @@ void island_coordinator::insert_to_island(entt::entity island_entity,
                 auto &point_resident = resident_view.get(point_entity);
                 point_resident.island_entity = island_entity;
 
-                ctx->m_delta_builder->created(point_entity);
-                ctx->m_delta_builder->created_all(point_entity, *m_registry);
+                ctx.m_delta_builder->created(point_entity);
+                ctx.m_delta_builder->created_all(point_entity, *m_registry);
             }
         }
     }
@@ -498,8 +522,7 @@ void island_coordinator::create_island(std::vector<entt::entity> nodes, bool sle
 #endif
 
     auto timestamp = performance_time();
-    auto island_entity = create_island(timestamp, sleeping);
-    insert_to_island(island_entity, nodes, {});
+    create_island(timestamp, sleeping, nodes, {});
 }
 
 void island_coordinator::refresh_dirty_entities() {
@@ -710,8 +733,7 @@ void island_coordinator::split_island(entt::entity split_island_entity) {
         // contain any procedural node.
         if (!contains_procedural) continue;
 
-        auto island_entity = create_island(timestamp, sleeping);
-        insert_to_island(island_entity, connected.nodes, connected.edges);
+        create_island(timestamp, sleeping, connected.nodes, connected.edges);
     }
 }
 


### PR DESCRIPTION
When a node is destroyed, destroy all edges connecting to it as well. 
When creating a new island, create a local dynamic tree containing the AABBs of the dynamic island nodes and assign its view to the island entity to prevent the island from existing without an `edyn::tree_view ` for a short period.