### PR TITLE
Position constraints

### DIFF
--- a/include/edyn/collision/collision_result.hpp
+++ b/include/edyn/collision/collision_result.hpp
@@ -6,6 +6,7 @@
 #include "edyn/math/quaternion.hpp"
 #include "edyn/config/constants.hpp"
 #include "edyn/util/array.hpp"
+#include "edyn/collision/contact_normal_attachment.hpp"
 
 namespace edyn {
 
@@ -15,6 +16,7 @@ struct collision_result {
         vector3 pivotB;
         vector3 normal;
         scalar distance;
+        contact_normal_attachment normal_attachment;
     };
 
     size_t num_points {0};

--- a/include/edyn/collision/contact_normal_attachment.hpp
+++ b/include/edyn/collision/contact_normal_attachment.hpp
@@ -1,0 +1,24 @@
+#ifndef EDYN_COLLISION_CONTACT_NORMAL_ATTACHMENT_HPP
+#define EDYN_COLLISION_CONTACT_NORMAL_ATTACHMENT_HPP
+
+namespace edyn {
+
+/**
+ * @brief To which body a contact normal is attached in a contact point.
+ * This is used while solving position contact constraints where the bodies
+ * are translated and rotated in each iteration, which causes the contact
+ * points to move. An approximation is made to place the contact points and
+ * contact normal in a new location where the closest points could be. If
+ * the closest feature on a body is planar, it is selected as the place
+ * where the contact normal is attached to, and thus it is rotated with this
+ * body in each iteration.
+ */
+enum class contact_normal_attachment {
+    none,
+    normal_on_A,
+    normal_on_B
+};
+
+}
+
+#endif // EDYN_COLLISION_CONTACT_NORMAL_ATTACHMENT_HPP

--- a/include/edyn/collision/contact_point.hpp
+++ b/include/edyn/collision/contact_point.hpp
@@ -6,25 +6,21 @@
 #include <entt/entity/fwd.hpp>
 #include <entt/entity/entity.hpp>
 #include "edyn/math/vector3.hpp"
+#include "edyn/collision/contact_normal_attachment.hpp"
 
 namespace edyn {
-
-enum class contact_normal_attachment {
-    normal_on_A,
-    normal_on_B
-};
 
 struct contact_point {
     std::array<entt::entity, 2> body {entt::null, entt::null};
     vector3 pivotA; // A's pivot in object space.
     vector3 pivotB; // B's pivot in object space.
     vector3 normal; // Normal in world space.
-    vector3 local_normal;
-    contact_normal_attachment normal_attachment;
-    scalar friction;
-    scalar restitution;
-    uint32_t lifetime {0};
-    scalar distance;
+    vector3 local_normal; // Normal in object space.
+    contact_normal_attachment normal_attachment; // To which body the normal is attached.
+    scalar friction; // Combined friction coefficient.
+    scalar restitution; // Combined coefficient of restitution.
+    uint32_t lifetime {0}; // Incremented in each simulation step where the contact is persisted.
+    scalar distance; // Signed distance along normal.
 };
 
 }

--- a/include/edyn/collision/contact_point.hpp
+++ b/include/edyn/collision/contact_point.hpp
@@ -9,11 +9,18 @@
 
 namespace edyn {
 
+enum class contact_normal_attachment {
+    normal_on_A,
+    normal_on_B
+};
+
 struct contact_point {
     std::array<entt::entity, 2> body {entt::null, entt::null};
     vector3 pivotA; // A's pivot in object space.
     vector3 pivotB; // B's pivot in object space.
     vector3 normal; // Normal in world space.
+    vector3 local_normal;
+    contact_normal_attachment normal_attachment;
     scalar friction;
     scalar restitution;
     uint32_t lifetime {0};

--- a/include/edyn/config/constants.hpp
+++ b/include/edyn/config/constants.hpp
@@ -51,6 +51,16 @@ inline constexpr auto island_time_to_sleep = scalar(2);
  */
 inline constexpr auto support_feature_tolerance = scalar(0.004);
 
+/**
+ * Error correction rate when solving contact position constraints.
+ */
+inline constexpr auto contact_position_correction_rate = scalar(0.2);
+
+/**
+ * Minimum acceptable error in the contact position solver.
+ */
+inline constexpr auto contact_position_solver_min_error = scalar(-0.005);
+
 }
 
 #endif // EDYN_CONFIG_CONSTANTS_HPP

--- a/include/edyn/constraints/constraint.hpp
+++ b/include/edyn/constraints/constraint.hpp
@@ -46,11 +46,11 @@ void iterate_constraints(entt::registry &registry, row_cache &cache, scalar dt) 
 }
 
 inline
-bool solve_position_constraints(entt::registry &registry) {
+bool solve_position_constraints(entt::registry &registry, scalar dt) {
     auto solved = false;
 
     std::apply([&] (auto ... c) {
-        solved = (solve_position_constraints<decltype(c)>(registry) && ...);
+        solved = (solve_position_constraints<decltype(c)>(registry, dt) && ...);
     }, constraints_tuple);
 
     return solved;

--- a/include/edyn/constraints/constraint.hpp
+++ b/include/edyn/constraints/constraint.hpp
@@ -45,6 +45,17 @@ void iterate_constraints(entt::registry &registry, row_cache &cache, scalar dt) 
     }, constraints_tuple);
 }
 
+inline
+bool solve_position_constraints(entt::registry &registry) {
+    auto solved = false;
+
+    std::apply([&] (auto ... c) {
+        solved = (solve_position_constraints<decltype(c)>(registry) && ...);
+    }, constraints_tuple);
+
+    return solved;
+}
+
 }
 
 #endif // EDYN_CONSTRAINTS_CONSTRAINT_HPP

--- a/include/edyn/constraints/contact_constraint.hpp
+++ b/include/edyn/constraints/contact_constraint.hpp
@@ -22,7 +22,7 @@ template<>
 void iterate_constraints<contact_constraint>(entt::registry &, row_cache &, scalar dt);
 
 template<>
-bool solve_position_constraints<contact_constraint>(entt::registry &registry);
+bool solve_position_constraints<contact_constraint>(entt::registry &registry, scalar dt);
 
 }
 

--- a/include/edyn/constraints/contact_constraint.hpp
+++ b/include/edyn/constraints/contact_constraint.hpp
@@ -11,8 +11,17 @@ namespace edyn {
 struct contact_constraint : public constraint_base {
     scalar stiffness {large_scalar};
     scalar damping {large_scalar};
+};
 
-    scalar m_friction {};
+struct contact_friction_row {
+    std::array<vector3, 4> J;
+    scalar eff_mass;
+    scalar rhs;
+    scalar impulse;
+};
+
+struct contact_constraint_context {
+    std::vector<contact_friction_row> friction_rows;
 };
 
 template<>

--- a/include/edyn/constraints/contact_constraint.hpp
+++ b/include/edyn/constraints/contact_constraint.hpp
@@ -19,6 +19,7 @@ namespace internal {
         scalar eff_mass;
         scalar rhs;
         scalar impulse;
+        scalar friction_coefficient;
     };
 
     struct contact_constraint_context {

--- a/include/edyn/constraints/contact_constraint.hpp
+++ b/include/edyn/constraints/contact_constraint.hpp
@@ -13,16 +13,18 @@ struct contact_constraint : public constraint_base {
     scalar damping {large_scalar};
 };
 
-struct contact_friction_row {
-    std::array<vector3, 4> J;
-    scalar eff_mass;
-    scalar rhs;
-    scalar impulse;
-};
+namespace internal {
+    struct contact_friction_row {
+        std::array<vector3, 4> J;
+        scalar eff_mass;
+        scalar rhs;
+        scalar impulse;
+    };
 
-struct contact_constraint_context {
-    std::vector<contact_friction_row> friction_rows;
-};
+    struct contact_constraint_context {
+        std::vector<contact_friction_row> friction_rows;
+    };
+}
 
 template<>
 void prepare_constraints<contact_constraint>(entt::registry &, row_cache &, scalar dt);

--- a/include/edyn/constraints/contact_constraint.hpp
+++ b/include/edyn/constraints/contact_constraint.hpp
@@ -19,11 +19,15 @@ namespace internal {
         scalar eff_mass;
         scalar rhs;
         scalar impulse;
+    };
+
+    struct contact_friction_row_pair {
+        contact_friction_row row[2];
         scalar friction_coefficient;
     };
 
     struct contact_constraint_context {
-        std::vector<contact_friction_row> friction_rows;
+        std::vector<contact_friction_row_pair> friction_rows;
     };
 }
 

--- a/include/edyn/constraints/contact_constraint.hpp
+++ b/include/edyn/constraints/contact_constraint.hpp
@@ -21,6 +21,9 @@ void prepare_constraints<contact_constraint>(entt::registry &, row_cache &, scal
 template<>
 void iterate_constraints<contact_constraint>(entt::registry &, row_cache &, scalar dt);
 
+template<>
+bool solve_position_constraints<contact_constraint>(entt::registry &registry);
+
 }
 
 #endif // EDYN_CONSTRAINTS_CONTACT_CONSTRAINT_HPP

--- a/include/edyn/constraints/prepare_constraints.hpp
+++ b/include/edyn/constraints/prepare_constraints.hpp
@@ -14,6 +14,9 @@ void prepare_constraints(entt::registry &, row_cache &, scalar dt) {}
 template<typename C>
 void iterate_constraints(entt::registry &, row_cache &, scalar dt) {}
 
+template<typename C>
+bool solve_position_constraints(entt::registry &) { return true; }
+
 }
 
 #endif // EDYN_CONSTRAINTS_PREPARE_CONSTRAINTS_HPP

--- a/include/edyn/constraints/prepare_constraints.hpp
+++ b/include/edyn/constraints/prepare_constraints.hpp
@@ -15,7 +15,7 @@ template<typename C>
 void iterate_constraints(entt::registry &, row_cache &, scalar dt) {}
 
 template<typename C>
-bool solve_position_constraints(entt::registry &) { return true; }
+bool solve_position_constraints(entt::registry &, scalar dt) { return true; }
 
 }
 

--- a/include/edyn/context/settings.hpp
+++ b/include/edyn/context/settings.hpp
@@ -18,7 +18,8 @@ struct settings {
     scalar fixed_dt {scalar(1.0 / 60)};
     bool paused {false};
     vector3 gravity {gravity_earth};
-    unsigned num_solver_iterations {10};
+    unsigned num_solver_velocity_iterations {8};
+    unsigned num_solver_position_iterations {3};
     make_island_delta_builder_func_t make_island_delta_builder {&make_island_delta_builder_default};
     external_system_func_t external_system_init {nullptr};
     external_system_func_t external_system_pre_step {nullptr};

--- a/include/edyn/dynamics/solver.hpp
+++ b/include/edyn/dynamics/solver.hpp
@@ -15,7 +15,8 @@ public:
 
     void update(scalar dt);
 
-    unsigned iterations {10};
+    unsigned velocity_iterations {8};
+    unsigned position_iterations {3};
 
 private:
     entt::registry *m_registry;

--- a/include/edyn/edyn.hpp
+++ b/include/edyn/edyn.hpp
@@ -273,18 +273,22 @@ vector3 get_gravity(const entt::registry &registry);
 void set_gravity(entt::registry &registry, vector3 gravity);
 
 /**
- * @brief Get the number of constraint solver iterations.
+ * @brief Get the number of constraint solver velocity iterations.
  * @param registry Data source.
- * @return Number of solver iterations.
+ * @return Number of solver velocity iterations.
  */
-unsigned get_solver_iterations(const entt::registry &registry);
+unsigned get_solver_velocity_iterations(const entt::registry &registry);
 
 /**
- * @brief Set the number of constraint solver iterations.
+ * @brief Set the number of constraint solver velocity iterations.
  * @param registry Data source.
- * @param iterations Number of solver iterations.
+ * @param iterations Number of solver velocity iterations.
  */
-void set_solver_iterations(entt::registry &registry, unsigned iterations);
+void set_solver_velocity_iterations(entt::registry &registry, unsigned iterations);
+
+unsigned get_solver_position_iterations(const entt::registry &registry);
+
+void set_solver_position_iterations(entt::registry &registry, unsigned iterations);
 
 }
 

--- a/include/edyn/edyn.hpp
+++ b/include/edyn/edyn.hpp
@@ -284,10 +284,26 @@ unsigned get_solver_velocity_iterations(const entt::registry &registry);
  * @param registry Data source.
  * @param iterations Number of solver velocity iterations.
  */
+
+/**
+ * @brief Set the number of constraint solver velocity iterations.
+ * @param registry Data source.
+ * @param iterations Number of solver velocity iterations.
+ */
 void set_solver_velocity_iterations(entt::registry &registry, unsigned iterations);
 
+/**
+ * @brief Get the number of constraint solver position iterations.
+ * @param registry Data source.
+ * @return Number of solver position iterations.
+ */
 unsigned get_solver_position_iterations(const entt::registry &registry);
 
+/**
+ * @brief Set the number of constraint solver position iterations.
+ * @param registry Data source.
+ * @param iterations Number of solver position iterations.
+ */
 void set_solver_position_iterations(entt::registry &registry, unsigned iterations);
 
 }

--- a/include/edyn/math/quaternion.hpp
+++ b/include/edyn/math/quaternion.hpp
@@ -22,6 +22,34 @@ struct quaternion {
 
 inline constexpr quaternion quaternion_identity {0, 0, 0, 1};
 
+// Add two quaternions.
+inline quaternion operator+(const quaternion& q0, const quaternion &q1) {
+    return {q0.x + q1.x, q0.y + q1.y, q0.z + q1.z, q0.w + q1.w};
+}
+
+// Add a quaternion into another quaternion.
+inline quaternion& operator+=(quaternion &q0, const quaternion &q1) {
+    q0.x += q1.x;
+    q0.y += q1.y;
+    q0.z += q1.z;
+    q0.w += q1.w;
+    return q0;
+}
+
+// Subtract two quaternions.
+inline quaternion operator-(const quaternion &q0, const quaternion &q1) {
+    return {q0.x - q1.x, q0.y - q1.y, q0.z - q1.z, q0.w - q1.w};
+}
+
+// Subtract a quaternion from another quaternion.
+inline quaternion& operator-=(quaternion &q0, const quaternion &q1) {
+    q0.x -= q1.x;
+    q0.y -= q1.y;
+    q0.z -= q1.z;
+    q0.w -= q1.w;
+    return q0;
+}
+
 // Multiply quaternion by scalar.
 inline quaternion operator*(const quaternion& q, scalar s) {
     return {q.x * s, q.y * s, q.z * s, q.w * s};

--- a/include/edyn/parallel/island_coordinator.hpp
+++ b/include/edyn/parallel/island_coordinator.hpp
@@ -66,7 +66,7 @@ public:
 
     void set_fixed_dt(scalar dt);
 
-    void set_solver_iterations(unsigned iterations);
+    void set_solver_iterations(unsigned velocity_iterations, unsigned position_iterations);
 
     void set_center_of_mass(entt::entity entity, const vector3 &com);
 

--- a/include/edyn/parallel/message.hpp
+++ b/include/edyn/parallel/message.hpp
@@ -15,7 +15,8 @@ struct set_fixed_dt {
 };
 
 struct set_solver_iterations {
-    unsigned iterations;
+    unsigned velocity_iterations;
+    unsigned position_iterations;
 };
 
 struct set_settings {

--- a/src/edyn/collision/collide/collide_box_box.cpp
+++ b/src/edyn/collision/collide/collide_box_box.cpp
@@ -126,7 +126,7 @@ void collide(const box_shape &shA, const box_shape &shB,
                 auto pivot_face = project_plane(face_verticesB[i], face_verticesA[0], face_normalA);
                 auto pivotA = to_object_space(pivot_face, posA, ornA);
                 auto pivotB = to_object_space(face_verticesB[i], posB, ornB);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
             }
         }
 
@@ -137,7 +137,7 @@ void collide(const box_shape &shA, const box_shape &shB,
                 auto pivot_face = project_plane(face_verticesA[i], face_verticesB[0], face_normalB);
                 auto pivotA = to_object_space(face_verticesA[i], posA, ornA);
                 auto pivotB = to_object_space(pivot_face, posB, ornB);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
             }
         }
 
@@ -164,7 +164,7 @@ void collide(const box_shape &shA, const box_shape &shB,
                     auto q0 = project_plane(q1, face_center, face_normalA);
                     auto pivotA = to_object_space(q0, posA, ornA);
                     auto pivotB = to_object_space(q1, posB, ornB);
-                    result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                    result.maybe_add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
                 }
             }
         }
@@ -179,6 +179,9 @@ void collide(const box_shape &shA, const box_shape &shB,
                                         shB.get_face(feature_indexB, posB, ornB);
         auto edge_vertices = is_faceA ? shB.get_edge(feature_indexB, posB, ornB) :
                                         shA.get_edge(feature_indexA, posA, ornA);
+        auto normal_attachment = is_faceA ?
+            contact_normal_attachment::normal_on_A :
+            contact_normal_attachment::normal_on_B;
 
         // Check if edge vertices are inside face.
         for (int i = 0; i < 2; ++i) {
@@ -189,7 +192,7 @@ void collide(const box_shape &shA, const box_shape &shB,
                                          to_object_space(edge_vertices[i], posA, ornA);
                 auto pivotB = is_faceA ? to_object_space(edge_vertices[i], posB, ornB) :
                                          to_object_space(pivot_face, posB, ornB);
-                result.add_point({pivotA, pivotB, sep_axis, distance});
+                result.add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         }
 
@@ -217,7 +220,7 @@ void collide(const box_shape &shA, const box_shape &shB,
                 auto face_pivot = project_plane(edge_pivot, face_center, sep_axis);
                 auto pivotA = to_object_space(is_faceA ? face_pivot : edge_pivot, posA, ornA);
                 auto pivotB = to_object_space(is_faceA ? edge_pivot : face_pivot, posB, ornB);
-                result.add_point({pivotA, pivotB, sep_axis, distance});
+                result.add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         }
     } else if (featureA == box_feature::edge && featureB == box_feature::edge) {
@@ -234,20 +237,20 @@ void collide(const box_shape &shA, const box_shape &shB,
         for (size_t i = 0; i < num_points; ++i) {
             auto pivotA = to_object_space(p0[i], posA, ornA);
             auto pivotB = to_object_space(p1[i], posB, ornB);
-            result.add_point({pivotA, pivotB, sep_axis, distance});
+            result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
         }
     } else if (featureA == box_feature::face && featureB == box_feature::vertex) {
         // Face A, Vertex B.
         auto pivotB = shB.get_vertex(feature_indexB);
         auto pivotA = to_world_space(pivotB, posB, ornB) + sep_axis * distance;
         pivotA = to_object_space(pivotA, posA, ornA);
-        result.add_point({pivotA, pivotB, sep_axis, distance});
+        result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_A});
     } else if (featureB == box_feature::face && featureA == box_feature::vertex) {
         // Face B, Vertex A.
         auto pivotA = shA.get_vertex(feature_indexA);
         auto pivotB = to_world_space(pivotA, posA, ornA) - sep_axis * distance;
         pivotB = to_object_space(pivotB, posB, ornB);
-        result.add_point({pivotA, pivotB, sep_axis, distance});
+        result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
     }
 }
 

--- a/src/edyn/collision/collide/collide_box_plane.cpp
+++ b/src/edyn/collision/collide/collide_box_plane.cpp
@@ -4,15 +4,15 @@
 
 namespace edyn {
 
-void collide(const box_shape &shA, const plane_shape &shB, 
+void collide(const box_shape &shA, const plane_shape &shB,
              const collision_context &ctx, collision_result &result) {
     auto center = shB.normal * shB.constant;
 
     box_feature featureA;
     size_t feature_indexA;
     scalar projectionA;
-    shA.support_feature(ctx.posA, ctx.ornA, center, -shB.normal, 
-                        featureA, feature_indexA, projectionA, 
+    shA.support_feature(ctx.posA, ctx.ornA, center, -shB.normal,
+                        featureA, feature_indexA, projectionA,
                         support_feature_tolerance);
     auto distance = -projectionA;
 
@@ -45,7 +45,7 @@ void collide(const box_shape &shA, const plane_shape &shB,
         auto pivotB_world = project_plane(pivotA_world, center, shB.normal);
         auto pivotB = to_object_space(pivotB_world, ctx.posB, ctx.ornB);
         auto local_distance = dot(pivotA_world - pivotB_world, shB.normal);
-        result.add_point({pivotA, pivotB, shB.normal, local_distance});
+        result.add_point({pivotA, pivotB, shB.normal, local_distance, contact_normal_attachment::normal_on_B});
     }
 }
 

--- a/src/edyn/collision/collide/collide_capsule_box.cpp
+++ b/src/edyn/collision/collide/collide_capsule_box.cpp
@@ -108,7 +108,7 @@ void collide(const capsule_shape &shA, const box_shape &shB,
                     auto pivotA = to_object_space(pointA - sep_axis * shA.radius, posA, ornA);
                     auto pivotB_world = project_plane(pointA, contact_origin_box, sep_axis);
                     auto pivotB = to_object_space(pivotB_world, posB, ornB);
-                    result.add_point({pivotA, pivotB, sep_axis, distance});
+                    result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
                 }
             }
 
@@ -136,7 +136,7 @@ void collide(const capsule_shape &shA, const box_shape &shB,
                 auto face_pivot = project_plane(edge_pivot, face_center, sep_axis);
                 auto pivotA = to_object_space(edge_pivot - sep_axis * shA.radius, posA, ornA);
                 auto pivotB = to_object_space(face_pivot, posB, ornB);
-                result.add_point({pivotA, pivotB, sep_axis, distance});
+                result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
             }
         } else {
             // Capsule edge vs box face.
@@ -146,7 +146,7 @@ void collide(const capsule_shape &shA, const box_shape &shB,
             auto pivotB_world = project_plane(pivotA_world, contact_origin_box, sep_axis);
             auto pivotA = to_object_space(pivotA_world, posA, ornA);
             auto pivotB = to_object_space(pivotB_world, posB, ornB);
-            result.add_point({pivotA, pivotB, sep_axis, distance});
+            result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
         }
         break;
     }
@@ -167,7 +167,7 @@ void collide(const capsule_shape &shA, const box_shape &shB,
                 auto pivotB_world = closestB[i];
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
                 auto pivotB = to_object_space(pivotB_world, posB, ornB);
-                result.add_point({pivotA, pivotB, sep_axis, distance});
+                result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
             }
         } else {
             // Capsule vertex against box edge.
@@ -178,7 +178,7 @@ void collide(const capsule_shape &shA, const box_shape &shB,
             closest_point_line(edge_vertices[0], edge_dir, closest_capsule_vertex, t, pivotB_world);
             auto pivotB = to_object_space(pivotB_world, posB, ornB);
             auto pivotA = to_object_space(closest_capsule_vertex - sep_axis * shA.radius, posA, ornA);
-            result.add_point({pivotA, pivotB, sep_axis, distance});
+            result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
         }
         break;
     }
@@ -187,7 +187,7 @@ void collide(const capsule_shape &shA, const box_shape &shB,
         auto pivotB_world = to_world_space(pivotB, posB, ornB);
         auto pivotA_world = pivotB_world + sep_axis * distance;
         auto pivotA = to_object_space(pivotA_world, posA, ornA);
-        result.add_point({pivotA, pivotB, sep_axis, distance});
+        result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
     }
     }
 }

--- a/src/edyn/collision/collide/collide_capsule_capsule.cpp
+++ b/src/edyn/collision/collide/collide_capsule_capsule.cpp
@@ -56,7 +56,7 @@ void collide(const capsule_shape &shA, const capsule_shape &shB,
         auto pivotB_world = closestB[i] + normal * shB.radius;
         auto pivotA = to_object_space(pivotA_world, posA, ornA);
         auto pivotB = to_object_space(pivotB_world, posB, ornB);
-        result.add_point({pivotA, pivotB, normal, distance});
+        result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::none});
     }
 }
 

--- a/src/edyn/collision/collide/collide_capsule_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_capsule_cylinder.cpp
@@ -169,7 +169,7 @@ void collide(const capsule_shape &shA, const cylinder_shape &shB,
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
                 auto pivotB = to_object_space(pivotB_world, posB, ornB);
                 auto local_distance = dot(pivotA_world - pivotB_world, sep_axis);
-                result.add_point({pivotA, pivotB, sep_axis, local_distance});
+                result.add_point({pivotA, pivotB, sep_axis, local_distance, contact_normal_attachment::normal_on_B});
             }
         } else {
             // Cylinder cap face against capsule vertex.
@@ -179,7 +179,7 @@ void collide(const capsule_shape &shA, const cylinder_shape &shB,
             auto pivotB_world = project_plane(closest_capsule_vertex, cylinder_vertices[feature_indexB], sep_axis);
             auto pivotA = to_object_space(pivotA_world, posA, ornA);
             auto pivotB = to_object_space(pivotB_world, posB, ornB);
-            result.add_point({pivotA, pivotB, sep_axis, distance});
+            result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
         }
         break;
     }
@@ -197,7 +197,7 @@ void collide(const capsule_shape &shA, const cylinder_shape &shB,
         for (size_t i = 0; i < num_points; ++i) {
             auto pivotA = to_object_space(closest_capsule[i] - sep_axis * shA.radius, posA, ornA);
             auto pivotB = to_object_space(closest_cylinder[i] + sep_axis * shB.radius, posB, ornB);
-            result.add_point({pivotA, pivotB, sep_axis, distance});
+            result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
         }
 
         break;
@@ -206,7 +206,7 @@ void collide(const capsule_shape &shA, const cylinder_shape &shB,
         auto supportB = shB.support_point(posB, ornB, sep_axis);
         auto pivotB = to_object_space(supportB, posB, ornB);
         auto pivotA = to_object_space(supportB + sep_axis * distance, posA, ornA);
-        result.add_point({pivotA, pivotB, sep_axis, distance});
+        result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
         break;
     }
     }

--- a/src/edyn/collision/collide/collide_capsule_mesh.cpp
+++ b/src/edyn/collision/collide/collide_capsule_mesh.cpp
@@ -108,6 +108,8 @@ static void collide_capsule_triangle(
 
     switch (tri_feature) {
     case triangle_feature::face: {
+        auto normal_attachment = contact_normal_attachment::normal_on_B;
+
         if (is_capsule_edge) {
             // Check if capsule vertex is inside triangle face.
             for (auto &vertex : capsule_vertices) {
@@ -116,7 +118,7 @@ static void collide_capsule_triangle(
                     auto pivotA = to_object_space(pivotA_world, posA, ornA);
                     auto pivotB = project_plane(vertex, tri_vertices[0], sep_axis);
                     auto local_distance = dot(pivotA_world - tri_vertices[0], sep_axis);
-                    result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
+                    result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 }
             }
 
@@ -153,7 +155,7 @@ static void collide_capsule_triangle(
                     auto pivotA = to_object_space(pivotA_world, posA, ornA);
                     auto pivotB = lerp(v0, v1, t[k]);
                     auto local_distance = dot(pivotA_world - tri_vertices[0], sep_axis);
-                    result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
+                    result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 }
             }
         } else {
@@ -164,7 +166,7 @@ static void collide_capsule_triangle(
                 auto pivotA_world = closest_capsule_vertex - sep_axis * capsule.radius;
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
                 auto pivotB = project_plane(closest_capsule_vertex, tri_vertices[0], sep_axis);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         }
         break;
@@ -172,6 +174,7 @@ static void collide_capsule_triangle(
     case triangle_feature::edge: {
         auto &v0 = tri_vertices[tri_feature_index];
         auto &v1 = tri_vertices[(tri_feature_index + 1) % 3];
+        auto normal_attachment = contact_normal_attachment::none;
 
         if (is_capsule_edge) {
             scalar s[2], t[2];
@@ -185,7 +188,7 @@ static void collide_capsule_triangle(
                 auto pivotA_world = closest_cap[i] - sep_axis * capsule.radius;
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
                 auto pivotB = closest_tri[i];
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         } else {
             auto &closest_capsule_vertex = capsule_vertices[capsule_vertex_index];
@@ -196,13 +199,14 @@ static void collide_capsule_triangle(
             if (!(length_sqr(cross(dir, sep_axis)) > EDYN_EPSILON)) {
                 auto pivotA_world = closest_capsule_vertex - sep_axis * capsule.radius;
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         }
         break;
     }
     case triangle_feature::vertex: {
         auto &pivotB = tri_vertices[tri_feature_index];
+        auto normal_attachment = contact_normal_attachment::none;
 
         if (is_capsule_edge) {
             auto edge = capsule_vertices[1] - capsule_vertices[0];
@@ -213,13 +217,13 @@ static void collide_capsule_triangle(
             if (!(length_sqr(cross(dir, sep_axis)) > EDYN_EPSILON)) {
                 auto pivotA_world = closest - sep_axis * capsule.radius;
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         } else {
             auto &closest_capsule_vertex = capsule_vertices[capsule_vertex_index];
             auto pivotA_world = closest_capsule_vertex - sep_axis * capsule.radius;
             auto pivotA = to_object_space(pivotA_world, posA, ornA);
-            result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+            result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
         }
     }
     }

--- a/src/edyn/collision/collide/collide_capsule_plane.cpp
+++ b/src/edyn/collision/collide/collide_capsule_plane.cpp
@@ -2,7 +2,7 @@
 
 namespace edyn {
 
-void collide(const capsule_shape &shA, const plane_shape &shB, 
+void collide(const capsule_shape &shA, const plane_shape &shB,
              const collision_context &ctx, collision_result &result) {
     auto center = shB.normal * shB.constant;
     auto capsule_vertices = shA.get_vertices(ctx.posA, ctx.ornA);
@@ -15,7 +15,7 @@ void collide(const capsule_shape &shA, const plane_shape &shB,
         auto pivotA_world = vertex - shB.normal * shA.radius;
         auto pivotA = to_object_space(pivotA_world, ctx.posA, ctx.ornA);
         auto pivotB = project_plane(vertex, center, shB.normal);
-        result.add_point({pivotA, pivotB, shB.normal, distance});
+        result.add_point({pivotA, pivotB, shB.normal, distance, contact_normal_attachment::normal_on_B});
     }
 }
 

--- a/src/edyn/collision/collide/collide_capsule_sphere.cpp
+++ b/src/edyn/collision/collide/collide_capsule_sphere.cpp
@@ -37,7 +37,7 @@ void collide(const capsule_shape &shA, const sphere_shape &shB,
     auto pivotA_world = closest - normal * shA.radius;
     auto pivotA = to_object_space(pivotA_world, ctx.posA, ctx.ornA);
 
-    result.add_point({pivotA, pivotB, normal, distance});
+    result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::none});
 }
 
 void collide(const sphere_shape &shA, const capsule_shape &shB,

--- a/src/edyn/collision/collide/collide_cylinder_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_cylinder.cpp
@@ -186,6 +186,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
     if (featureA == cylinder_feature::face && featureB == cylinder_feature::face) {
         auto posA_in_B = to_object_space(posA, posB, ornB);
         auto ornA_in_B = conjugate(ornB) * ornA;
+        auto normal_attachment = contact_normal_attachment::normal_on_B;
 
         // Intersect the cylinder cap face circles in 2D, in B's space. The
         // cylinder axis is the x axis locally, thus use the z axis in 3D as
@@ -214,7 +215,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                 auto pivotA = to_object_space(pivotB, posA_in_B, ornA_in_B);
                 pivotA.x = pivotA_x;
                 auto local_distance = get_local_distance(pivotA, pivotB);
-                result.add_point({pivotA, pivotB, sep_axis, local_distance});
+                result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
             }
 
             auto dist_sqr = length_sqr(centerA);
@@ -239,7 +240,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                     // Faces do not line up perfectly, thus calculate the distance
                     // for each pivot.
                     auto local_distance = get_local_distance(pivotA, pivotB);
-                    result.add_point({pivotA, pivotB, sep_axis, local_distance});
+                    result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 }
 
                 {
@@ -248,7 +249,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                     auto pivotA = to_object_space(pivotB, posA_in_B, ornA_in_B);
                     pivotA.x = pivotA_x;
                     auto local_distance = get_local_distance(pivotA, pivotB);
-                    result.add_point({pivotA, pivotB, sep_axis, local_distance});
+                    result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 }
             } else if (dist_sqr < shB.radius * shB.radius || dist_sqr < shA.radius * shA.radius) {
                 // Circles intersect at a single point and the center of one is contained
@@ -265,14 +266,14 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                     auto pivotA = to_object_space(pivotB, posA_in_B, ornA_in_B);
                     pivotA.x = pivotA_x;
                     auto local_distance = get_local_distance(pivotA, pivotB);
-                    result.add_point({pivotA, pivotB, sep_axis, local_distance});
+                    result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 } else {
                     auto extra_B = dir * shB.radius;
                     auto pivotB = vector3{pivotB_x, extra_B.y, extra_B.x};
                     auto pivotA = to_object_space(pivotB, posA_in_B, ornA_in_B);
                     pivotA.x = pivotA_x;
                     auto local_distance = get_local_distance(pivotA, pivotB);
-                    result.add_point({pivotA, pivotB, sep_axis, local_distance});
+                    result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 }
 
                 // Add 2 points in the orthogonal direction.
@@ -283,25 +284,29 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                     auto pivotB = vector3{pivotB_x, extra_A0.y, extra_A0.x};
                     auto pivotA = to_object_space(pivotB, posA_in_B, ornA_in_B);
                     pivotA.x = pivotA_x;
-                    result.add_point({pivotA, pivotB, sep_axis, get_local_distance(pivotA, pivotB)});
+                    auto local_distance = get_local_distance(pivotA, pivotB);
+                    result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
 
                     auto extra_A1 = centerA - dir * shA.radius;
                     pivotB = vector3{pivotB_x, extra_A1.y, extra_A1.x};
                     pivotA = to_object_space(pivotB, posA_in_B, ornA_in_B);
                     pivotA.x = pivotA_x;
-                    result.add_point({pivotA, pivotB, sep_axis, get_local_distance(pivotA, pivotB)});
+                    local_distance = get_local_distance(pivotA, pivotB);
+                    result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 } else {
                     auto extra_B0 = dir * shB.radius;
                     auto pivotB = vector3{pivotB_x, extra_B0.y, extra_B0.x};
                     auto pivotA = to_object_space(pivotB, posA_in_B, ornA_in_B);
                     pivotA.x = pivotA_x;
-                    result.add_point({pivotA, pivotB, sep_axis, get_local_distance(pivotA, pivotB)});
+                    auto local_distance = get_local_distance(pivotA, pivotB);
+                    result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
 
                     auto extra_B1 = -dir * shB.radius;
                     pivotB = vector3{pivotB_x, extra_B1.y, extra_B1.x};
                     pivotA = to_object_space(pivotB, posA_in_B, ornA_in_B);
                     pivotA.x = pivotA_x;
-                    result.add_point({pivotA, pivotB, sep_axis, get_local_distance(pivotA, pivotB)});
+                    local_distance = get_local_distance(pivotA, pivotB);
+                    result.add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 }
             }
         } else {
@@ -325,7 +330,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                     auto pivotA = to_world_space(pivotB, posB_in_A, ornB_in_A);
                     pivotA.x = shA.half_length * to_sign(feature_indexA == 0);
                     auto local_distance = get_local_distance(pivotA, pivotB);
-                    result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
+                    result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 }
             } else if (distance_sqr_line(posB, axisB, circle_pointA) < shB.radius * shB.radius) {
                 for(size_t i = 0; i < 4; ++i) {
@@ -336,7 +341,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
                     auto pivotB = to_world_space(pivotA, posA_in_B, ornA_in_B);
                     pivotB.x = shB.half_length * to_sign(feature_indexB == 0);
                     auto local_distance = get_local_distance(pivotA, pivotB);
-                    result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
+                    result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 }
             }
         }
@@ -346,14 +351,14 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
         auto pivotA_world = project_plane(supportB, verticesA[feature_indexA], sep_axis);
         auto pivotA = to_object_space(pivotA_world, posA, ornA);
         auto pivotB = to_object_space(supportB, posB, ornB);
-        result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+        result.maybe_add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_A});
     } else if (featureA == cylinder_feature::cap_edge &&
                featureB == cylinder_feature::face) {
         auto supportA = shA.support_point(posA, ornA, -sep_axis);
         auto pivotA = to_object_space(supportA, posA, ornA);
         auto pivotB_world = project_plane(supportA, verticesB[feature_indexB], sep_axis);
         auto pivotB = to_object_space(pivotB_world, posB, ornB);
-        result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+        result.maybe_add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::normal_on_B});
     } else if (featureA == cylinder_feature::face &&
                featureB == cylinder_feature::side_edge) {
         // Transform vertices to cylinder space.
@@ -372,7 +377,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
             auto normalB = rotate(conjugate(ornB), sep_axis);
             auto pivotB = vector3_x * shB.half_length * (1 - 2 * s[i]) + normalB * shB.radius;
             auto local_distance = get_local_distance(pivotA, pivotB);
-            result.add_point({pivotA, pivotB, sep_axis, local_distance});
+            result.add_point({pivotA, pivotB, sep_axis, local_distance, contact_normal_attachment::normal_on_A});
         }
     } else if (featureA == cylinder_feature::side_edge &&
                featureB == cylinder_feature::face) {
@@ -392,7 +397,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
             auto normalA = rotate(conjugate(ornA), sep_axis);
             auto pivotA = vector3_x * shA.half_length * (1 - 2 * s[i]) - normalA * shA.radius;
             auto local_distance = get_local_distance(pivotA, pivotB);
-            result.add_point({pivotA, pivotB, sep_axis, local_distance});
+            result.add_point({pivotA, pivotB, sep_axis, local_distance, contact_normal_attachment::normal_on_B});
         }
     } else if (featureA == cylinder_feature::side_edge &&
                featureB == cylinder_feature::side_edge) {
@@ -409,7 +414,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
             auto pivotB_world = closestB[i] + sep_axis * shB.radius;
             auto pivotA = to_object_space(pivotA_world, posA, ornA);
             auto pivotB = to_object_space(pivotB_world, posB, ornB);
-            result.add_point({pivotA, pivotB, sep_axis, distance});
+            result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
         }
     } else if (featureA == cylinder_feature::side_edge &&
                featureB == cylinder_feature::cap_edge) {
@@ -419,7 +424,7 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
 
         auto pivotB = to_object_space(supportB, posB, ornB);
         pivotA = to_object_space(pivotA - sep_axis * shA.radius, posA, ornA);
-        result.add_point({pivotA, pivotB, sep_axis, distance});
+        result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
     } else if (featureB == cylinder_feature::side_edge &&
                featureA == cylinder_feature::cap_edge) {
         auto supportA = shA.support_point(posA, ornA, -sep_axis);
@@ -428,14 +433,14 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
 
         auto pivotA = to_object_space(supportA, posA, ornA);
         pivotB = to_object_space(pivotB + sep_axis * shB.radius, posB, ornB);
-        result.add_point({pivotA, pivotB, sep_axis, distance});
+        result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
     } else if (featureA == cylinder_feature::cap_edge &&
                featureB == cylinder_feature::cap_edge) {
         auto supportA = shA.support_point(posA, ornA, -sep_axis);
         auto supportB = shB.support_point(posB, ornB, sep_axis);
         auto pivotA = to_object_space(supportA, posA, ornA);
         auto pivotB = to_object_space(supportB, posB, ornB);
-        result.add_point({pivotA, pivotB, sep_axis, distance});
+        result.add_point({pivotA, pivotB, sep_axis, distance, contact_normal_attachment::none});
     }
 }
 

--- a/src/edyn/collision/collide/collide_cylinder_mesh.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_mesh.cpp
@@ -139,6 +139,7 @@ void collide_cylinder_triangle(
     if (cyl_feature == cylinder_feature::face && tri_feature == triangle_feature::face) {
         size_t num_vertices_in_face = 0;
         auto sign_faceA = to_sign(cyl_feature_index == 0);
+        auto normal_attachment = contact_normal_attachment::normal_on_B;
 
         // Check if triangle vertices are inside a cylinder cap face (by checking
         // if its distance from the cylinder axis is smaller than the cylinder radius).
@@ -151,7 +152,7 @@ void collide_cylinder_triangle(
             auto pivotA = to_object_space(vertex, posA, ornA);
             pivotA.x = cylinder.half_length * sign_faceA;
             auto pivotB = vertex;
-            result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+            result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
 
             ++num_vertices_in_face;
         }
@@ -178,7 +179,7 @@ void collide_cylinder_triangle(
 
             auto local_distance = dot(pivotA_world - tri_vertices[0], tri_normal);
             auto pivotB = pivotA_world - tri_normal * local_distance;
-            result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
+            result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
         }
 
         // Check if circle and triangle edges intersect.
@@ -209,7 +210,7 @@ void collide_cylinder_triangle(
                 auto pivotA = lerp(v0_A, v1_A, t);
                 pivotA.x = pivotA_x;
                 auto pivotB = lerp(v0, v1, t);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         }
     } else if (cyl_feature == cylinder_feature::face && tri_feature == triangle_feature::edge) {
@@ -231,6 +232,7 @@ void collide_cylinder_triangle(
 
         auto sign_faceA = to_sign(cyl_feature_index == 0);
         auto pivotA_x = cylinder.half_length * sign_faceA;
+        auto normal_attachment = contact_normal_attachment::normal_on_A;
 
         for (size_t pt_idx = 0; pt_idx < num_points; ++pt_idx) {
             auto t = clamp_unit(s[pt_idx]);
@@ -238,7 +240,7 @@ void collide_cylinder_triangle(
             auto local_distance = (pivotA.x - pivotA_x) * sign_faceA;
             pivotA.x = pivotA_x;
             auto pivotB = lerp(edge_vertices[0], edge_vertices[1], t);
-            result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
+            result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
         }
     } else if (cyl_feature == cylinder_feature::face && tri_feature == triangle_feature::vertex) {
         auto vertex = tri_vertices[tri_feature_index];
@@ -249,13 +251,15 @@ void collide_cylinder_triangle(
             auto pivotA = to_object_space(vertex, posA, ornA);
             pivotA.x = cylinder.half_length * to_sign(cyl_feature_index == 0);
             auto pivotB = vertex;
-            result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+            auto normal_attachment = contact_normal_attachment::normal_on_A;
+            result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
         }
     } else if (cyl_feature == cylinder_feature::side_edge && tri_feature == triangle_feature::face) {
         // Check if edge vertices are inside triangle face.
         size_t num_edge_vert_in_tri_face = 0;
 
         auto radial_dir = normalize(project_direction(-sep_axis, cylinder_axis));
+        auto normal_attachment = contact_normal_attachment::normal_on_B;
 
         for (auto vertex : cylinder_vertices) {
             if (point_in_triangle(tri_vertices, tri_normal, vertex)) {
@@ -263,7 +267,7 @@ void collide_cylinder_triangle(
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
                 auto local_distance = dot(pivotA_world - tri_vertices[0], sep_axis);
                 auto pivotB = pivotA_world - sep_axis * local_distance;
-                result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
                 ++num_edge_vert_in_tri_face;
             }
         }
@@ -306,7 +310,7 @@ void collide_cylinder_triangle(
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
                 auto pivotB = lerp(v0, v1, t[k]);
                 auto local_distance = dot(pivotA_world - pivotB, sep_axis);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, local_distance, normal_attachment});
             }
         }
     } else if (cyl_feature == cylinder_feature::side_edge && tri_feature == triangle_feature::edge) {
@@ -320,11 +324,13 @@ void collide_cylinder_triangle(
                                         &s[1], &t[1], &closestA[1], &closestB[1]);
 
         if (num_points > 0) {
+            auto normal_attachment = contact_normal_attachment::none;
+
             for (size_t i = 0; i < num_points; ++i) {
                 auto pivotA_world = closestA[i] - sep_axis * cylinder.radius;
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
                 auto pivotB = closestB[i];
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         }
     } else if (cyl_feature == cylinder_feature::side_edge && tri_feature == triangle_feature::vertex) {
@@ -334,20 +340,23 @@ void collide_cylinder_triangle(
         auto pivotA_world = closest - sep_axis * cylinder.radius;
         auto pivotA = to_object_space(pivotA_world, posA, ornA);
         auto pivotB = vertex;
-        result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+        auto normal_attachment = contact_normal_attachment::none;
+        result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
     } else if (cyl_feature == cylinder_feature::cap_edge && tri_feature == triangle_feature::face) {
         auto supportA = cylinder.support_point(posA, ornA, -sep_axis);
 
         if (point_in_triangle(tri_vertices, tri_normal, supportA)) {
             auto pivotA = to_object_space(supportA, posA, ornA);
             auto pivotB = project_plane(supportA, tri_vertices[0], tri_normal);
-            result.maybe_add_point({pivotA, pivotB, tri_normal, distance});
+            auto normal_attachment = contact_normal_attachment::normal_on_B;
+            result.maybe_add_point({pivotA, pivotB, tri_normal, distance, normal_attachment});
         }
     } else if (cyl_feature == cylinder_feature::cap_edge && tri_feature == triangle_feature::edge) {
         auto supportA = cylinder.support_point(posA, ornA, -sep_axis);
         auto pivotA = to_object_space(supportA, posA, ornA);
         auto pivotB = supportA - sep_axis * distance;
-        result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+        auto normal_attachment = contact_normal_attachment::none;
+        result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
     }
 }
 

--- a/src/edyn/collision/collide/collide_cylinder_plane.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_plane.cpp
@@ -22,6 +22,7 @@ void collide(const cylinder_shape &shA, const plane_shape &shB,
     size_t feature_indexA;
     shA.support_feature(posA, ornA, -normal, featureA, feature_indexA,
                         support_feature_tolerance);
+    auto normal_attachment = contact_normal_attachment::normal_on_B;
 
     switch (featureA) {
     case cylinder_feature::face:{
@@ -35,7 +36,7 @@ void collide(const cylinder_shape &shA, const plane_shape &shB,
             auto pivotA_world = to_world_space(pivotA, posA, ornA);
             auto pivotB = project_plane(pivotA_world, center, normal);
             auto local_distance = dot(pivotA_world - pivotB, normal);
-            result.maybe_add_point({pivotA, pivotB, normal, local_distance});
+            result.maybe_add_point({pivotA, pivotB, normal, local_distance, normal_attachment});
         }
         break;
     }
@@ -64,7 +65,7 @@ void collide(const cylinder_shape &shA, const plane_shape &shB,
             auto pivotA = to_object_space(pivotA_world, posA, ornA);
             auto pivotB = project_plane(pivotA_world, center, normal);
             auto local_distance = dot(pivotA_world - pivotB, normal);
-            result.maybe_add_point({pivotA, pivotB, normal, local_distance});
+            result.maybe_add_point({pivotA, pivotB, normal, local_distance, normal_attachment});
         }
         break;
     }

--- a/src/edyn/collision/collide/collide_polyhedron_plane.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_plane.cpp
@@ -23,6 +23,7 @@ void collide(const polyhedron_shape &shA, const plane_shape &shB,
     auto polygon = point_cloud_support_polygon(
         rmeshA.vertices.begin(), rmeshA.vertices.end(), vector3_zero,
         normal, proj_poly, true, support_feature_tolerance);
+    auto normal_attachment = contact_normal_attachment::normal_on_B;
 
     for (auto idxA : polygon.hull) {
         auto &pointA = polygon.vertices[idxA];
@@ -30,7 +31,7 @@ void collide(const polyhedron_shape &shA, const plane_shape &shB,
         auto pivotA = rotate(conjugate(ctx.ornA), pointA);
         auto local_distance = dot(pointA - center, normal);
         auto pivotB = pointA - normal * local_distance + posA; // Project onto plane.
-        result.maybe_add_point({pivotA, pivotB, normal, local_distance});
+        result.maybe_add_point({pivotA, pivotB, normal, local_distance, normal_attachment});
     }
 }
 

--- a/src/edyn/collision/collide/collide_polyhedron_polyhedron.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_polyhedron.cpp
@@ -134,6 +134,14 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
         rmeshB.vertices.begin(), rmeshB.vertices.end(), posB,
         sep_axis, projectionB, false, support_feature_tolerance);
 
+    auto normal_attachment = contact_normal_attachment::none;
+
+    if (polygonB.hull.size() > 2) {
+        normal_attachment = contact_normal_attachment::normal_on_B;
+    } else if (polygonA.hull.size() > 2) {
+        normal_attachment = contact_normal_attachment::normal_on_A;
+    }
+
     // First, add contact points for vertices that lie inside the opposing face.
     // If the feature on B is a face, i.e. `verticesB` has 3 or more elements,
     // check if the points in `verticesA` lie inside the prism spanned by `verticesB`
@@ -146,7 +154,7 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
                 auto pivotA = to_object_space(pointA, posA, ornA);
                 auto pivotB_world = project_plane(pointA, polygonB.origin, sep_axis);
                 auto pivotB = to_object_space(pivotB_world, posB, ornB);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         }
     }
@@ -159,7 +167,7 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
                 auto pivotB = to_object_space(pointB, posB, ornB);
                 auto pivotA_world = project_plane(pointB, polygonA.origin, sep_axis);
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
             }
         }
     }
@@ -194,7 +202,7 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
                     auto pivotB_world = lerp(polygonB.vertices[idx0B], polygonB.vertices[idx1B], t[k]);
                     auto pivotA = to_object_space(pivotA_world, posA, ornA);
                     auto pivotB = to_object_space(pivotB_world, posB, ornB);
-                    result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+                    result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
                 }
             }
         }

--- a/src/edyn/collision/collide/collide_polyhedron_sphere.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_sphere.cpp
@@ -57,7 +57,7 @@ void collide(const polyhedron_shape &shA, const sphere_shape &shB,
         auto normalB = rotate(conjugate(ornB), sep_axis);
         auto pivotB = normalB * shB.radius;
         auto normal = rotate(ctx.ornA, sep_axis);
-        result.add_point({pivotA, pivotB, normal, distance});
+        result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::normal_on_A});
         return;
     }
 
@@ -85,7 +85,7 @@ void collide(const polyhedron_shape &shA, const sphere_shape &shB,
     auto pivotB = normalB * shB.radius;
     auto normal = rotate(ctx.ornA, new_sep_axis);
 
-    result.add_point({pivotA, pivotB, normal, distance});
+    result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::none});
 }
 
 void collide(const sphere_shape &shA, const polyhedron_shape &shB,

--- a/src/edyn/collision/collide/collide_sphere_box.cpp
+++ b/src/edyn/collision/collide/collide_sphere_box.cpp
@@ -1,5 +1,6 @@
 #include "edyn/collision/collide.hpp"
 #include "edyn/math/geom.hpp"
+#include "edyn/math/scalar.hpp"
 
 namespace edyn {
 
@@ -21,15 +22,27 @@ void collide(const sphere_shape &shA, const box_shape &shB,
     }
 
     scalar center_distance;
+    auto normal_attachment = contact_normal_attachment::none;
 
     // If `posA_in_B` lies inside the box, `closest_point_box_outside`
     // returns `posA_in_B`.
     if (d_sqr <= EDYN_EPSILON) {
         // Sphere center lies inside box.
         center_distance = -closest_point_box_inside(shB.half_extents, posA_in_B, closest, normalB);
+        normal_attachment = contact_normal_attachment::normal_on_B;
     } else {
         center_distance = std::sqrt(d_sqr);
         normalB /= center_distance;
+
+        // If the local normal is aligned with any of the coordinate axes, it
+        // means the closest feature on the box is a face and thus the normal
+        // should be attached to the box.
+        if (std::abs(normalB.x) > scalar(1) - EDYN_EPSILON ||
+            std::abs(normalB.y) > scalar(1) - EDYN_EPSILON ||
+            std::abs(normalB.z) > scalar(1) - EDYN_EPSILON)
+        {
+            normal_attachment = contact_normal_attachment::normal_on_B;
+        }
     }
 
     auto pivotA_in_B = posA_in_B - normalB * shA.radius;
@@ -38,7 +51,7 @@ void collide(const sphere_shape &shA, const box_shape &shB,
     auto pivotB = closest;
     auto normal = rotate(ctx.ornB, normalB);
     auto distance = center_distance - shA.radius;
-    result.add_point({pivotA, pivotB, normal, distance});
+    result.add_point({pivotA, pivotB, normal, distance, normal_attachment});
 }
 
 void collide(const box_shape &shA, const sphere_shape &shB,

--- a/src/edyn/collision/collide/collide_sphere_mesh.cpp
+++ b/src/edyn/collision/collide/collide_sphere_mesh.cpp
@@ -73,7 +73,8 @@ static void collide_sphere_triangle(
         if (point_in_triangle(tri_vertices, tri_normal, sphere_pos)) {
             auto pivotA = rotate(conjugate(sphere_orn), -tri_normal * sphere.radius);
             auto pivotB = project_plane(sphere_pos, tri_vertices[0], tri_normal);
-            result.maybe_add_point({pivotA, pivotB, tri_normal, distance});
+            auto normal_attachment = contact_normal_attachment::normal_on_B;
+            result.maybe_add_point({pivotA, pivotB, tri_normal, distance, normal_attachment});
         }
         break;
     }
@@ -86,14 +87,16 @@ static void collide_sphere_triangle(
 
         if (t > 0 && t < 1) {
             auto pivotA = rotate(conjugate(sphere_orn), -sep_axis * sphere.radius);
-            result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+            auto normal_attachment = contact_normal_attachment::none;
+            result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
         }
         break;
     }
     case triangle_feature::vertex: {
         auto pivotA = rotate(conjugate(sphere_orn), -sep_axis * sphere.radius);
         auto &pivotB = tri_vertices[tri_feature_index];
-        result.maybe_add_point({pivotA, pivotB, sep_axis, distance});
+        auto normal_attachment = contact_normal_attachment::none;
+        result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
     }
     }
 }

--- a/src/edyn/collision/collide/collide_sphere_plane.cpp
+++ b/src/edyn/collision/collide/collide_sphere_plane.cpp
@@ -16,7 +16,7 @@ void collide(const sphere_shape &sphere, const plane_shape &plane,
     auto pivotA = rotate(conjugate(ctx.ornA), -normal * sphere.radius);
     auto pivotB = rotate(conjugate(ctx.ornB), d - normal * l - center);
     auto distance = l - sphere.radius;
-    result.add_point({pivotA, pivotB, plane.normal, distance});
+    result.add_point({pivotA, pivotB, plane.normal, distance, contact_normal_attachment::normal_on_B});
 }
 
 void collide(const plane_shape &shA, const sphere_shape &shB,

--- a/src/edyn/collision/collide/collide_sphere_sphere.cpp
+++ b/src/edyn/collision/collide/collide_sphere_sphere.cpp
@@ -23,7 +23,7 @@ void collide(const sphere_shape &shA, const sphere_shape &shB,
     auto pivotB = rB;
     auto normal = dn;
     auto distance = l - shA.radius - shB.radius;
-    result.add_point({pivotA, pivotB, normal, distance});
+    result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::none});
 }
 
 }

--- a/src/edyn/constraints/contact_constraint.cpp
+++ b/src/edyn/constraints/contact_constraint.cpp
@@ -14,9 +14,8 @@
 #include "edyn/collision/contact_point.hpp"
 #include "edyn/constraints/constraint_impulse.hpp"
 #include "edyn/dynamics/row_cache.hpp"
-#include "edyn/math/quaternion.hpp"
-#include "edyn/math/scalar.hpp"
-#include "edyn/math/vector3.hpp"
+#include "edyn/math/geom.hpp"
+#include "edyn/math/math.hpp"
 #include "edyn/util/constraint_util.hpp"
 #include <entt/entity/registry.hpp>
 
@@ -36,8 +35,11 @@ void prepare_constraints<contact_constraint>(entt::registry &registry, row_cache
     size_t start_idx = cache.rows.size();
     registry.ctx_or_set<row_start_index_contact_constraint>().value = start_idx;
 
-    size_t num_rows_per_constraint = 2;
-    cache.rows.reserve(cache.rows.size() + con_view.size() * num_rows_per_constraint);
+    cache.rows.reserve(cache.rows.size() + con_view.size());
+
+    auto &ctx = registry.ctx<contact_constraint_context>();
+    ctx.friction_rows.clear();
+    ctx.friction_rows.reserve(con_view.size() * 2);
 
     con_view.each([&] (entt::entity entity, contact_constraint &con, contact_point &cp) {
         auto [posA, ornA, linvelA, angvelA, inv_mA, inv_IA, dvA, dwA] =
@@ -82,62 +84,111 @@ void prepare_constraints<contact_constraint>(entt::registry &registry, row_cache
         normal_row.impulse = imp.values[0];
         normal_row.lower_limit = 0;
 
-        if (con.stiffness < large_scalar) {
-            auto spring_force = cp.distance * con.stiffness;
-            auto damper_force = normal_relvel * con.damping;
-            normal_row.upper_limit = std::abs(spring_force + damper_force) * dt;
-        } else {
-            normal_row.upper_limit = large_scalar;
-        }
-
         auto normal_options = constraint_row_options{};
         normal_options.restitution = cp.restitution;
 
-        if (cp.distance > 0) {
-            auto penetration_vel = cp.distance / dt;
-            normal_options.error = penetration_vel;
+        if (cp.distance < 0) {
+            if (con.stiffness < large_scalar) {
+                auto spring_force = cp.distance * con.stiffness;
+                auto damper_force = normal_relvel * con.damping;
+                normal_row.upper_limit = std::abs(spring_force + damper_force) * dt;
+            } else {
+                normal_row.upper_limit = large_scalar;
+            }
+        } else if (con.stiffness >= large_scalar) {
+            // It is not penetrating thus apply an impulse that will prevent
+            // penetration after the following physics update.
+            normal_options.error = cp.distance / dt;
+            normal_row.upper_limit = large_scalar;
         }
 
         prepare_row(normal_row, normal_options, linvelA, linvelB, angvelA, angvelB);
         warm_start(normal_row);
 
-        // Create friction row.
-        auto tangent_relvel = relvel - normal * normal_relvel;
-        auto tangent_relspd = length(tangent_relvel);
-        auto tangent = tangent_relspd > EDYN_EPSILON ?
-            tangent_relvel / tangent_relspd : vector3_x;
+        // Create special friction rows.
+        vector3 tangents[2];
+        plane_space(normal, tangents[0], tangents[1]);
 
-        auto &friction_row = cache.rows.emplace_back();
-        friction_row.J = {tangent, cross(rA, tangent), -tangent, -cross(rB, tangent)};
-        friction_row.inv_mA = inv_mA; friction_row.inv_IA = inv_IA;
-        friction_row.inv_mB = inv_mB; friction_row.inv_IB = inv_IB;
-        friction_row.dvA = &dvA; friction_row.dwA = &dwA;
-        friction_row.dvB = &dvB; friction_row.dwB = &dwB;
-        friction_row.impulse = imp.values[1];
-        // friction_row limits are calculated in `iterate_contact_constraints`
-        // using the normal impulse.
-        friction_row.lower_limit = friction_row.upper_limit = 0;
+        for (auto i = 0; i < 2; ++i) {
+            auto &friction_row = ctx.friction_rows.emplace_back();
+            friction_row.J = {tangents[i], cross(rA, tangents[i]), -tangents[i], -cross(rB, tangents[i])};
+            friction_row.impulse = imp.values[1 + i];
 
-        prepare_row(friction_row, {}, linvelA, linvelB, angvelA, angvelB);
-        warm_start(friction_row);
+            auto J_invM_JT = dot(friction_row.J[0], friction_row.J[0]) * inv_mA +
+                             dot(inv_IA * friction_row.J[1], friction_row.J[1]) +
+                             dot(friction_row.J[2], friction_row.J[2]) * inv_mB +
+                             dot(inv_IB * friction_row.J[3], friction_row.J[3]);
+            friction_row.eff_mass = 1 / J_invM_JT;
 
-        con.m_friction = cp.friction;
+            auto relvel = dot(friction_row.J[0], linvelA) +
+                          dot(friction_row.J[1], angvelA) +
+                          dot(friction_row.J[2], linvelB) +
+                          dot(friction_row.J[3], angvelB);
+            friction_row.rhs = -relvel;
 
-        cache.con_num_rows.push_back(num_rows_per_constraint);
+            // Warm-starting.
+            dvA += inv_mA * friction_row.J[0] * friction_row.impulse;
+            dwA += inv_IA * friction_row.J[1] * friction_row.impulse;
+            dvB += inv_mB * friction_row.J[2] * friction_row.impulse;
+            dwB += inv_IB * friction_row.J[3] * friction_row.impulse;
+        }
+
+        cache.con_num_rows.push_back(1);
     });
 }
 
 template<>
 void iterate_constraints<contact_constraint>(entt::registry &registry, row_cache &cache, scalar dt) {
-    auto con_view = registry.view<contact_constraint>();
+    auto con_view = registry.view<contact_point>();
     auto row_idx = registry.ctx<row_start_index_contact_constraint>().value;
+    auto &ctx = registry.ctx<contact_constraint_context>();
+    auto friction_idx = size_t{0};
 
-    con_view.each([&] (contact_constraint &con) {
-        const auto &normal_row = cache.rows[row_idx++];
-        auto &friction_row = cache.rows[row_idx++];
-        auto friction_impulse = std::abs(normal_row.impulse * con.m_friction);
-        friction_row.lower_limit = -friction_impulse;
-        friction_row.upper_limit = friction_impulse;
+    // Solve friction rows locally using a non-standard method where the impulse
+    // is limited by the length of a 2D vector to assure a friction circle.
+    // This is essentially the same fundamental operations found in `edyn::solver`
+    // adapted to couple the two friction constraints together.
+    con_view.each([&] (contact_point &cp) {
+        auto &normal_row = cache.rows[row_idx++];
+        auto *friction_rows = &ctx.friction_rows[friction_idx];
+        vector2 delta_impulse;
+        vector2 impulse;
+
+        for (auto i = 0; i < 2; ++i) {
+            auto &friction_row = friction_rows[i];
+            auto delta_relvel = dot(friction_row.J[0], *normal_row.dvA) +
+                                dot(friction_row.J[1], *normal_row.dwA) +
+                                dot(friction_row.J[2], *normal_row.dvB) +
+                                dot(friction_row.J[3], *normal_row.dwB);
+            delta_impulse[i] = (friction_row.rhs - delta_relvel) * friction_row.eff_mass;
+            impulse[i] = friction_row.impulse + delta_impulse[i];
+        }
+
+        auto impulse_len_sqr = length_sqr(impulse);
+        auto max_impulse_len = cp.friction * normal_row.impulse;
+
+        // Limit impulse by normal load.
+        if (impulse_len_sqr > square(max_impulse_len) && impulse_len_sqr > EDYN_EPSILON) {
+            auto impulse_len = std::sqrt(impulse_len_sqr);
+            impulse = impulse / impulse_len * max_impulse_len;
+
+            for (auto i = 0; i < 2; ++i) {
+                delta_impulse[i] = impulse[i] - friction_rows[i].impulse;
+            }
+        }
+
+        // Apply delta impulse.
+        for (auto i = 0; i < 2; ++i) {
+            auto &friction_row = friction_rows[i];
+            friction_row.impulse = impulse[i];
+
+            *normal_row.dvA += normal_row.inv_mA * friction_row.J[0] * delta_impulse[i];
+            *normal_row.dwA += normal_row.inv_IA * friction_row.J[1] * delta_impulse[i];
+            *normal_row.dvB += normal_row.inv_mB * friction_row.J[2] * delta_impulse[i];
+            *normal_row.dwB += normal_row.inv_IB * friction_row.J[3] * delta_impulse[i];
+        }
+
+        friction_idx += 2;
     });
 }
 

--- a/src/edyn/constraints/contact_constraint.cpp
+++ b/src/edyn/constraints/contact_constraint.cpp
@@ -38,7 +38,7 @@ void prepare_constraints<contact_constraint>(entt::registry &registry, row_cache
 
     cache.rows.reserve(cache.rows.size() + con_view.size());
 
-    auto &ctx = registry.ctx<contact_constraint_context>();
+    auto &ctx = registry.ctx<internal::contact_constraint_context>();
     ctx.friction_rows.clear();
     ctx.friction_rows.reserve(con_view.size() * 2);
 
@@ -142,7 +142,7 @@ template<>
 void iterate_constraints<contact_constraint>(entt::registry &registry, row_cache &cache, scalar dt) {
     auto con_view = registry.view<contact_point>();
     auto row_idx = registry.ctx<row_start_index_contact_constraint>().value;
-    auto &ctx = registry.ctx<contact_constraint_context>();
+    auto &ctx = registry.ctx<internal::contact_constraint_context>();
     auto friction_idx = size_t{0};
 
     // Solve friction rows locally using a non-standard method where the impulse

--- a/src/edyn/constraints/contact_constraint.cpp
+++ b/src/edyn/constraints/contact_constraint.cpp
@@ -40,7 +40,7 @@ void prepare_constraints<contact_constraint>(entt::registry &registry, row_cache
 
     auto &ctx = registry.ctx<internal::contact_constraint_context>();
     ctx.friction_rows.clear();
-    ctx.friction_rows.reserve(con_view.size() * 2);
+    ctx.friction_rows.reserve(con_view.size());
 
     con_view.each([&] (entt::entity entity, contact_constraint &con, contact_point &cp) {
         auto [posA, ornA, linvelA, angvelA, inv_mA, inv_IA, dvA, dwA] =

--- a/src/edyn/dynamics/solver.cpp
+++ b/src/edyn/dynamics/solver.cpp
@@ -64,21 +64,21 @@ void update_impulse<contact_constraint>(entt::registry &registry, row_cache &cac
     auto con_view = registry.view<contact_constraint>();
     auto imp_view = registry.view<constraint_impulse>();
     auto &ctx = registry.ctx<internal::contact_constraint_context>();
-    auto friction_idx = size_t{0};
+    auto local_idx = size_t{0};
 
     for (auto entity : con_view) {
         auto &imp = imp_view.get(entity);
         imp.values[0] = cache.rows[row_idx].impulse;
 
-        auto *friction_rows = &ctx.friction_rows[friction_idx];
+        auto &friction_rows = ctx.friction_rows[local_idx];
 
         for (auto i = 0; i < 2; ++i) {
-            imp.values[1 + i] = friction_rows[i].impulse;
+            imp.values[1 + i] = friction_rows.row[i].impulse;
         }
 
         ++row_idx;
         ++con_idx;
-        friction_idx += 2;
+        ++local_idx;
     }
 }
 

--- a/src/edyn/dynamics/solver.cpp
+++ b/src/edyn/dynamics/solver.cpp
@@ -120,7 +120,7 @@ void solver::update(scalar dt) {
     integrate_angvel(registry, dt);
 
     for (unsigned i = 0; i < position_iterations; ++i) {
-        if (solve_position_constraints(registry)) {
+        if (solve_position_constraints(registry, dt)) {
             break;
         }
     }

--- a/src/edyn/dynamics/solver.cpp
+++ b/src/edyn/dynamics/solver.cpp
@@ -92,7 +92,7 @@ void solver::update(scalar dt) {
     prepare_constraints(registry, m_row_cache, dt);
 
     // Solve constraints.
-    for (uint32_t i = 0; i < iterations; ++i) {
+    for (unsigned i = 0; i < velocity_iterations; ++i) {
         // Prepare constraints for iteration.
         iterate_constraints(registry, m_row_cache, dt);
 
@@ -118,6 +118,12 @@ void solver::update(scalar dt) {
     // Integrate velocities to obtain new transforms.
     integrate_linvel(registry, dt);
     integrate_angvel(registry, dt);
+
+    for (unsigned i = 0; i < position_iterations; ++i) {
+        if (solve_position_constraints(registry)) {
+            break;
+        }
+    }
 
     // Update rotated vertices of convex meshes after rotations change. It is
     // important to do this before `update_aabbs` because the rotated meshes

--- a/src/edyn/dynamics/solver.cpp
+++ b/src/edyn/dynamics/solver.cpp
@@ -63,7 +63,7 @@ template<>
 void update_impulse<contact_constraint>(entt::registry &registry, row_cache &cache, size_t &con_idx, size_t &row_idx) {
     auto con_view = registry.view<contact_constraint>();
     auto imp_view = registry.view<constraint_impulse>();
-    auto &ctx = registry.ctx<contact_constraint_context>();
+    auto &ctx = registry.ctx<internal::contact_constraint_context>();
     auto friction_idx = size_t{0};
 
     for (auto entity : con_view) {
@@ -103,7 +103,7 @@ solver::solver(entt::registry &registry)
     registry.on_construct<linvel>().connect<&entt::registry::emplace<delta_linvel>>();
     registry.on_construct<angvel>().connect<&entt::registry::emplace<delta_angvel>>();
 
-    registry.set<contact_constraint_context>();
+    registry.set<internal::contact_constraint_context>();
 }
 
 solver::~solver() = default;

--- a/src/edyn/edyn.cpp
+++ b/src/edyn/edyn.cpp
@@ -172,13 +172,28 @@ void set_gravity(entt::registry &registry, vector3 gravity) {
     }
 }
 
-unsigned get_solver_iterations(const entt::registry &registry) {
-    return registry.ctx<settings>().num_solver_iterations;
+unsigned get_solver_velocity_iterations(const entt::registry &registry) {
+    return registry.ctx<settings>().num_solver_velocity_iterations;
 }
 
-void set_solver_iterations(entt::registry &registry, unsigned iterations) {
-    registry.ctx<settings>().num_solver_iterations = iterations;
-    registry.ctx<island_coordinator>().set_solver_iterations(iterations);
+void set_solver_velocity_iterations(entt::registry &registry, unsigned iterations) {
+    auto &settings = registry.ctx<edyn::settings>();
+    settings.num_solver_velocity_iterations = iterations;
+    registry.ctx<island_coordinator>().set_solver_iterations(
+        settings.num_solver_velocity_iterations,
+        settings.num_solver_position_iterations);
+}
+
+unsigned get_solver_position_iterations(const entt::registry &registry) {
+    return registry.ctx<settings>().num_solver_position_iterations;
+}
+
+void set_solver_position_iterations(entt::registry &registry, unsigned iterations) {
+    auto &settings = registry.ctx<edyn::settings>();
+    settings.num_solver_position_iterations = iterations;
+    registry.ctx<island_coordinator>().set_solver_iterations(
+        settings.num_solver_velocity_iterations,
+        settings.num_solver_position_iterations);
 }
 
 }

--- a/src/edyn/parallel/island_coordinator.cpp
+++ b/src/edyn/parallel/island_coordinator.cpp
@@ -770,10 +770,10 @@ void island_coordinator::set_fixed_dt(scalar dt) {
     }
 }
 
-void island_coordinator::set_solver_iterations(unsigned iterations) {
+void island_coordinator::set_solver_iterations(unsigned velocity_iterations, unsigned position_iterations) {
     for (auto &pair : m_island_ctx_map) {
         auto &ctx = pair.second;
-        ctx->send<msg::set_solver_iterations>(iterations);
+        ctx->send<msg::set_solver_iterations>(velocity_iterations, position_iterations);
     }
 }
 

--- a/src/edyn/parallel/island_worker.cpp
+++ b/src/edyn/parallel/island_worker.cpp
@@ -68,7 +68,8 @@ island_worker::island_worker(entt::entity island_entity, const settings &setting
     m_registry.prepare<collision_filter>();
     m_registry.prepare<collision_exclusion>();
 
-    m_solver.iterations = settings.num_solver_iterations;
+    m_solver.velocity_iterations = settings.num_solver_velocity_iterations;
+    m_solver.position_iterations = settings.num_solver_position_iterations;
 
     m_island_entity = m_registry.create();
     m_entity_map.insert(island_entity, m_island_entity);
@@ -838,8 +839,11 @@ void island_worker::on_set_fixed_dt(const msg::set_fixed_dt &msg) {
 }
 
 void island_worker::on_set_solver_iterations(const msg::set_solver_iterations &msg) {
-    m_registry.ctx<edyn::settings>().num_solver_iterations = msg.iterations;
-    m_solver.iterations = msg.iterations;
+    auto &settings = m_registry.ctx<edyn::settings>();
+    settings.num_solver_velocity_iterations = msg.velocity_iterations;
+    settings.num_solver_position_iterations = msg.position_iterations;
+    m_solver.velocity_iterations = msg.velocity_iterations;
+    m_solver.position_iterations = msg.position_iterations;
 }
 
 void island_worker::on_set_settings(const msg::set_settings &msg) {

--- a/src/edyn/util/collision_util.cpp
+++ b/src/edyn/util/collision_util.cpp
@@ -108,7 +108,9 @@ entt::entity create_contact_point(entt::registry& registry,
         manifold.body,
         rp.pivotA, // pivotA
         rp.pivotB, // pivotB
-        rp.normal, // normal
+        rp.normal, // world space normal
+        rp.local_normal, // object space normal
+        rp.normal_attachment, // to which rigid body the local normal is attached
         scalar{}, // friction
         scalar{}, // restitution
         uint32_t{0}, // lifetime


### PR DESCRIPTION
Use position constraints to fix positional errors in contacts, thus replacing Baumgarte stabilization.
Use two friction directions with a special solver to limit the impulse by the magnitude of the combined impulse in both directions. Closes #1 .