### PR TITLE
Compile performance_time for all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ add_library(Edyn
     src/edyn/serialization/paged_triangle_mesh_s11n.cpp
     src/edyn/context/settings.cpp
     src/edyn/edyn.cpp
+    src/edyn/time/common/time.cpp
 )
 add_library(Edyn::Edyn ALIAS Edyn)
 

--- a/src/edyn/time/common/time.cpp
+++ b/src/edyn/time/common/time.cpp
@@ -1,0 +1,11 @@
+#include "edyn/time/time.hpp"
+
+namespace edyn {
+
+double performance_time()
+{
+    return static_cast<double>(performance_counter()) /
+           static_cast<double>(performance_frequency());
+}
+
+}

--- a/src/edyn/time/unix/time.cpp
+++ b/src/edyn/time/unix/time.cpp
@@ -191,10 +191,4 @@ void delay(uint32_t ms) {
     } while (was_error && (errno == EINTR));
 }
 
-double performance_time()
-{
-    return static_cast<double>(performance_counter()) /
-           static_cast<double>(performance_frequency());
-}
-
 }


### PR DESCRIPTION
This fixes the linking error on Windows; there are however still some conversions errors.