### PR TITLE
constexpr math

### DIFF
--- a/include/edyn/math/geom.hpp
+++ b/include/edyn/math/geom.hpp
@@ -300,13 +300,11 @@ bool point_in_polygonal_prism(const std::vector<vector3> &vertices,
 
 template<size_t N>
 constexpr bool point_in_polygonal_prism(const std::array<vector3, N> &vertices,
-                              const vector3 &normal, const vector3 &point) noexcept {
-    
-    const auto count = vertices.size();
-    static_assert(count > 2);
+                                        const vector3 &normal, const vector3 &point) noexcept {
+    static_assert(N > 2);
 
-    for (size_t i = 0; i < count; ++i) {
-        const auto j = (i + 1) % count;
+    for (size_t i = 0; i < N; ++i) {
+        const auto j = (i + 1) % N;
         auto &v0 = vertices[i];
         auto &v1 = vertices[j];
         auto d = v1 - v0;

--- a/include/edyn/math/geom.hpp
+++ b/include/edyn/math/geom.hpp
@@ -27,7 +27,7 @@ namespace edyn {
  * @return The squared distance between `q(t)` an `p`.
  */
 scalar closest_point_segment(const vector3 &q0, const vector3 &q1,
-                             const vector3 &p, scalar &t, vector3 &q);
+                             const vector3 &p, scalar &t, vector3 &q) noexcept;
 
 /**
  * @brief Computes the squared distance between a point and a line.
@@ -37,7 +37,7 @@ scalar closest_point_segment(const vector3 &q0, const vector3 &q1,
  * @return Square of distance between point and line.
  */
 scalar distance_sqr_line(const vector3 &q0, const vector3 &dir,
-                         const vector3 &p);
+                         const vector3 &p) noexcept;
 
 /**
  * @brief Computes the point in the line `q(t) = q0 + t*dir` closest
@@ -51,7 +51,7 @@ scalar distance_sqr_line(const vector3 &q0, const vector3 &dir,
  * @return The squared distance between `q(t)` an `p`.
  */
 scalar closest_point_line(const vector3 &q0, const vector3 &dir,
-                          const vector3 &p, scalar &t, vector3 &r);
+                          const vector3 &p, scalar &t, vector3 &r) noexcept;
 
 /**
  * @brief Computes the parameters for the closest points of two *non-parallel*
@@ -67,7 +67,7 @@ scalar closest_point_line(const vector3 &q0, const vector3 &dir,
  */
 bool closest_point_line_line(const vector3 &p1, const vector3 &q1,
                              const vector3 &p2, const vector3 &q2,
-                             scalar &s, scalar &t);
+                             scalar &s, scalar &t) noexcept;
 
 /**
  * @brief Computes the closest points `c1` and `c2` of segments
@@ -102,10 +102,10 @@ scalar closest_point_segment_segment(const vector3 &p1, const vector3 &q1,
                                      vector3 &c1, vector3 &c2,
                                      size_t *num_points = nullptr,
                                      scalar *sp = nullptr, scalar *tp = nullptr,
-                                     vector3 *c1p = nullptr, vector3 *c2p = nullptr);
+                                     vector3 *c1p = nullptr, vector3 *c2p = nullptr) noexcept;
 
 scalar closest_point_disc(const vector3 &dpos, const quaternion &dorn, scalar radius,
-                          const vector3 &p, vector3 &q);
+                          const vector3 &p, vector3 &q) noexcept;
 
 /**
  * Computes the closest points between a line `p(s) = p0 + s*(p1 - p0)` and a circle.
@@ -135,7 +135,7 @@ scalar closest_point_circle_line(
     const vector3 &p0, const vector3 &p1, size_t &num_points,
     scalar &s0, vector3 &rc0, vector3 &rl0,
     scalar &s1, vector3 &rc1, vector3 &rl1,
-    vector3 &normal, scalar threshold = support_feature_tolerance);
+    vector3 &normal, scalar threshold = support_feature_tolerance) noexcept;
 
 scalar closest_point_circle_circle(
     const vector3 &posA, const quaternion &ornA, scalar radiusA,
@@ -180,7 +180,7 @@ size_t intersect_segments(const vector2 &p0, const vector2 &p1,
  * @return Number of intersections.
  */
 size_t intersect_line_circle(const vector2 &p0, const vector2 &p1,
-                             scalar radius, scalar &s0, scalar &s1);
+                             scalar radius, scalar &s0, scalar &s1) noexcept;
 
 /**
  * @brief Intersect two circles in 2D.
@@ -194,14 +194,14 @@ size_t intersect_line_circle(const vector2 &p0, const vector2 &p1,
  */
 size_t intersect_circle_circle(const vector2 &posA, scalar radiusA,
                                const vector2 &posB, scalar radiusB,
-                               vector2 &res0, vector2 &res1);
+                               vector2 &res0, vector2 &res1) noexcept;
 
 vector3 support_point_circle(const vector3 &pos, const quaternion &orn,
-                             scalar radius, const vector3 &dir);
+                             scalar radius, const vector3 &dir) noexcept;
 
 template<size_t N>
-void support_point_vertices(const std::array<vector3, N> &vertices,
-                              const vector3 &dir, size_t &idx, scalar &proj) {
+constexpr void support_point_vertices(const std::array<vector3, N> &vertices,
+                              const vector3 &dir, size_t &idx, scalar &proj) noexcept {
     proj = -EDYN_SCALAR_MAX;
 
     for (size_t i = 0; i < N; ++i) {
@@ -214,7 +214,7 @@ void support_point_vertices(const std::array<vector3, N> &vertices,
     }
 }
 
-scalar area_4_points(const vector3 &p0, const vector3 &p1, const vector3 &p2, const vector3 &p3);
+scalar area_4_points(const vector3 &p0, const vector3 &p1, const vector3 &p2, const vector3 &p3) noexcept;
 
 enum class point_insertion_type {
     none,
@@ -233,14 +233,14 @@ insertion_point_result insertion_point_index(const vector3 *points,
                                              size_t count,
                                              size_t &num_points,
                                              const vector3 &new_point,
-                                             scalar new_point_depth);
+                                             scalar new_point_depth) noexcept;
 
-template<size_t N> inline
+template<size_t N>
 insertion_point_result insertion_point_index(const std::array<vector3, N> &points,
                                              const std::array<scalar, N> &depths,
                                              size_t &num_points,
                                              const vector3 &new_point,
-                                             scalar new_point_depth) {
+                                             scalar new_point_depth) noexcept {
     return insertion_point_index(points.data(), depths.data(), N, num_points, new_point, new_point_depth);
 }
 
@@ -252,7 +252,7 @@ insertion_point_result insertion_point_index(const std::array<vector3, N> &point
  * @return Point on the box surface closest to `p`, or `p` if `p` is contained
  *         in the box.
  */
-vector3 closest_point_box_outside(const vector3 &half_extent, const vector3 &p);
+vector3 closest_point_box_outside(const vector3 &half_extent, const vector3 &p) noexcept;
 
 /**
  * Finds the point closest to the internal point `p` on the surface of the
@@ -265,7 +265,7 @@ vector3 closest_point_box_outside(const vector3 &half_extent, const vector3 &p);
  * @return Distance between closest points.
  */
 scalar closest_point_box_inside(const vector3 &half_extent, const vector3 &p,
-                                vector3 &closest, vector3 &normal);
+                                vector3 &closest, vector3 &normal) noexcept;
 
 /**
  * Intersect a line with an AABB in the Cartesian plane.
@@ -281,7 +281,7 @@ scalar closest_point_box_inside(const vector3 &half_extent, const vector3 &p,
  */
 size_t intersect_line_aabb(const vector2 &p0, const vector2 &p1,
                            const vector2 &aabb_min, const vector2 &aabb_max,
-                           scalar &s0, scalar &s1);
+                           scalar &s0, scalar &s1) noexcept;
 
 /**
  * @brief Checks if a point lies inside the prism with base defined by a convex
@@ -296,13 +296,14 @@ size_t intersect_line_aabb(const vector2 &p0, const vector2 &p1,
  */
 bool point_in_polygonal_prism(const std::vector<vector3> &vertices,
                               const std::vector<size_t> &indices,
-                              const vector3 &normal, const vector3 &point);
+                              const vector3 &normal, const vector3 &point) noexcept;
 
 template<size_t N>
-bool point_in_polygonal_prism(const std::array<vector3, N> &vertices,
-                              const vector3 &normal, const vector3 &point) {
+constexpr bool point_in_polygonal_prism(const std::array<vector3, N> &vertices,
+                              const vector3 &normal, const vector3 &point) noexcept {
+    
     const auto count = vertices.size();
-    EDYN_ASSERT(count > 2);
+    static_assert(count > 2);
 
     for (size_t i = 0; i < count; ++i) {
         const auto j = (i + 1) % count;
@@ -328,7 +329,7 @@ bool point_in_polygonal_prism(const std::array<vector3, N> &vertices,
  * @return Whether segment intersects AABB.
  */
 bool intersect_segment_aabb(vector3 p0, vector3 p1,
-                            vector3 aabb_min, vector3 aabb_max);
+                            vector3 aabb_min, vector3 aabb_max) noexcept;
 
 struct intersect_ray_cylinder_result {
     enum class kind {
@@ -353,7 +354,7 @@ struct intersect_ray_cylinder_result {
  * @param u Output intersection parameter.
  * @return Result containing intersection situation, the distance and normal.
  */
-intersect_ray_cylinder_result intersect_ray_cylinder(vector3 p0, vector3 p1, vector3 pos, quaternion orn, scalar radius, scalar half_length, scalar &u);
+intersect_ray_cylinder_result intersect_ray_cylinder(vector3 p0, vector3 p1, vector3 pos, quaternion orn, scalar radius, scalar half_length, scalar &u) noexcept;
 
 /**
  * @brief Intersects a ray with a sphere.
@@ -365,7 +366,7 @@ intersect_ray_cylinder_result intersect_ray_cylinder(vector3 p0, vector3 p1, vec
  * @param t Output intersection parameter.
  * @return Whether ray intersects sphere.
  */
-bool intersect_ray_sphere(vector3 p0, vector3 p1, vector3 pos, scalar radius, scalar &t);
+bool intersect_ray_sphere(vector3 p0, vector3 p1, vector3 pos, scalar radius, scalar &t) noexcept;
 
 /**
  * @brief Intersects a ray with a triangle.
@@ -378,7 +379,7 @@ bool intersect_ray_sphere(vector3 p0, vector3 p1, vector3 pos, scalar radius, sc
  */
 bool intersect_segment_triangle(const vector3 &p0, const vector3 &p1,
                                 const std::array<vector3, 3> &vertices,
-                                const vector3 &normal, scalar &t);
+                                const vector3 &normal, scalar &t) noexcept;
 
 }
 

--- a/include/edyn/math/math.hpp
+++ b/include/edyn/math/math.hpp
@@ -11,14 +11,14 @@ namespace edyn {
 /**
  * @return Value of `radians` converted to degrees.
  */
-inline scalar to_degrees(scalar radians) {
+constexpr scalar to_degrees(scalar radians) noexcept {
     return radians / pi * 180;
 }
 
 /**
  * @return Value of `degress` converted to radians.
  */
-inline scalar to_radians(scalar degrees) {
+constexpr scalar to_radians(scalar degrees) noexcept {
     return degrees / 180 * pi;
 }
 
@@ -27,7 +27,7 @@ inline scalar to_radians(scalar degrees) {
  * @param Nm_per_degree Nm/degree.
  * @return Torque in Nm/rad.
  */
-inline scalar to_Nm_per_radian(scalar Nm_per_degree) {
+constexpr scalar to_Nm_per_radian(scalar Nm_per_degree) noexcept {
     return Nm_per_degree * to_degrees(1);
 }
 
@@ -36,21 +36,21 @@ inline scalar to_Nm_per_radian(scalar Nm_per_degree) {
  * @param Nm_per_radian Nm/rad.
  * @return Torque in Nm/degree.
  */
-inline scalar to_Nm_per_degree(scalar Nm_per_radian) {
+constexpr scalar to_Nm_per_degree(scalar Nm_per_radian) noexcept {
     return Nm_per_radian / to_degrees(1);
 }
 
 /**
  * @return Scalar clamped to the [0, 1] interval.
  */
-inline scalar clamp_unit(scalar s) {
+constexpr scalar clamp_unit(scalar s) noexcept {
     return std::clamp(s, scalar(0), scalar(1));
 }
 
 /**
  * @return Angle in [-π, π].
  */
-inline scalar normalize_angle(scalar s) {
+inline scalar normalize_angle(scalar s) noexcept {
     s = std::fmod(s, pi2);
 
     if (s < -pi) {
@@ -66,7 +66,7 @@ inline scalar normalize_angle(scalar s) {
  * @return Linear interpolation between `a` and `b` by scalar `s`.
  */
 template<typename T, typename Scalar>
-inline auto lerp(T a, T b, Scalar s) {
+constexpr auto lerp(T a, T b, Scalar s) noexcept {
     return a * (Scalar(1) - s) + b * s;
 }
 
@@ -74,14 +74,14 @@ inline auto lerp(T a, T b, Scalar s) {
  * @return The square of a number.
  */
 template<typename T>
-inline auto square(T a) {
+constexpr auto square(T a) noexcept {
     return a * a;
 }
 
 /**
  * @return 1 if `b` is true, -1 if `b is false.
  */
-inline auto to_sign(bool b) {
+constexpr auto to_sign(bool b) noexcept {
     return b ? scalar(1) : scalar(-1);
 }
 
@@ -91,7 +91,7 @@ inline auto to_sign(bool b) {
  * @return Average value.
  */
 template<typename T, size_t N>
-inline auto average(const std::array<T, N> &array) {
+constexpr auto average(const std::array<T, N> &array) noexcept {
     auto sum = array[0];
     for (size_t i = 1; i < N; ++i) {
         sum += array[i];

--- a/include/edyn/math/matrix3x3.hpp
+++ b/include/edyn/math/matrix3x3.hpp
@@ -12,25 +12,25 @@ namespace edyn {
 struct matrix3x3 {
     std::array<vector3, 3> row;
 
-    vector3 & operator[](size_t i) {
+    constexpr vector3& operator[](size_t i) noexcept {
         EDYN_ASSERT(i < 3);
         return row[i];
     }
 
-    const vector3 & operator[](size_t i) const {
+    constexpr const vector3& operator[](size_t i) const noexcept {
         EDYN_ASSERT(i < 3);
         return row[i];
     }
 
-    inline vector3 column(size_t i) const {
+    constexpr vector3 column(size_t i) const noexcept {
         return {row[0][i], row[1][i], row[2][i]};
     }
 
-    inline scalar column_dot(size_t i, const vector3 &v) const {
+    constexpr scalar column_dot(size_t i, const vector3 &v) const noexcept {
         return row[0][i] * v.x + row[1][i] * v.y + row[2][i] * v.z;
     }
 
-    inline scalar determinant() const {
+    constexpr scalar determinant() const noexcept {
         return triple_product(row[0], row[1], row[2]);
     }
 };
@@ -42,17 +42,17 @@ inline constexpr matrix3x3 matrix3x3_identity {{vector3_x, vector3_y, vector3_z}
 inline constexpr matrix3x3 matrix3x3_zero {{vector3_zero, vector3_zero, vector3_zero}};
 
 // Add two matrices.
-inline matrix3x3 operator+(const matrix3x3 &m, const matrix3x3 &n) {
+constexpr matrix3x3 operator+(const matrix3x3 &m, const matrix3x3 &n) noexcept {
     return {m.row[0] + n.row[0], m.row[1] + n.row[1], m.row[2] + n.row[2]};
 }
 
 // Subtract two matrices.
-inline matrix3x3 operator-(const matrix3x3 &m, const matrix3x3 &n) {
+constexpr matrix3x3 operator-(const matrix3x3 &m, const matrix3x3 &n) noexcept {
     return {m.row[0] - n.row[0], m.row[1] - n.row[1], m.row[2] - n.row[2]};
 }
 
 // Multiply two matrices.
-inline matrix3x3 operator*(const matrix3x3 &m, const matrix3x3 &n) {
+constexpr matrix3x3 operator*(const matrix3x3 &m, const matrix3x3 &n) noexcept {
     return {
         vector3{n.column_dot(0, m.row[0]), n.column_dot(1, m.row[0]), n.column_dot(2, m.row[0])},
         vector3{n.column_dot(0, m.row[1]), n.column_dot(1, m.row[1]), n.column_dot(2, m.row[1])},
@@ -61,28 +61,28 @@ inline matrix3x3 operator*(const matrix3x3 &m, const matrix3x3 &n) {
 }
 
 // Multiply vector by matrix.
-inline vector3 operator*(const matrix3x3 &m, const vector3 &v) {
+constexpr vector3 operator*(const matrix3x3 &m, const vector3 &v) noexcept {
     return {dot(m.row[0], v), dot(m.row[1], v), dot(m.row[2], v)};
 }
 
 // Multiply vector by matrix on the right, effectively multiplying
 // by the transpose.
-inline vector3 operator*(const vector3 &v, const matrix3x3 &m) {
+constexpr vector3 operator*(const vector3 &v, const matrix3x3 &m) noexcept {
     return {m.column_dot(0, v), m.column_dot(1, v), m.column_dot(2, v)};
 }
 
 // Multiply matrix by scalar.
-inline matrix3x3 operator*(const matrix3x3& m, scalar s) {
+constexpr matrix3x3 operator*(const matrix3x3& m, scalar s) noexcept {
     return {m[0] * s, m[1] * s, m[2] * s};
 }
 
 // Multiply scalar by matrix.
-inline matrix3x3 operator*(scalar s, const matrix3x3& m) {
+constexpr matrix3x3 operator*(scalar s, const matrix3x3& m) noexcept {
     return {s * m[0], s * m[1], s * m[2]};
 }
 
 // Add one matrix to another.
-inline matrix3x3 & operator+=(matrix3x3 &m, const matrix3x3 &n) {
+constexpr matrix3x3 & operator+=(matrix3x3 &m, const matrix3x3 &n) noexcept {
     m.row[0] += n.row[0];
     m.row[1] += n.row[1];
     m.row[2] += n.row[2];
@@ -90,7 +90,7 @@ inline matrix3x3 & operator+=(matrix3x3 &m, const matrix3x3 &n) {
 }
 
 // Subtract one matrix from another.
-inline matrix3x3 operator-=(matrix3x3 &m, const matrix3x3 &n) {
+constexpr matrix3x3 operator-=(matrix3x3 &m, const matrix3x3 &n) noexcept {
     m.row[0] -= n.row[0];
     m.row[1] -= n.row[1];
     m.row[2] -= n.row[2];
@@ -98,19 +98,19 @@ inline matrix3x3 operator-=(matrix3x3 &m, const matrix3x3 &n) {
 }
 
 // Check if two matrices are equal.
-inline bool operator==(const matrix3x3 &m, const matrix3x3 &n) {
+constexpr bool operator==(const matrix3x3 &m, const matrix3x3 &n) noexcept {
     return m.row == n.row;
 }
 
 // Check if two matrices are different.
-inline bool operator!=(const matrix3x3 &m, const matrix3x3 &n) {
+constexpr bool operator!=(const matrix3x3 &m, const matrix3x3 &n) noexcept {
     return m.row != n.row;
 }
 
 // Create a matrix with the given column vectors.
-inline matrix3x3 matrix3x3_columns(const vector3 &v0,
+constexpr matrix3x3 matrix3x3_columns(const vector3 &v0,
                                    const vector3 &v1,
-                                   const vector3 &v2) {
+                                   const vector3 &v2) noexcept {
     return {
         vector3{v0.x, v1.x, v2.x},
         vector3{v0.y, v1.y, v2.y},
@@ -119,12 +119,12 @@ inline matrix3x3 matrix3x3_columns(const vector3 &v0,
 }
 
 // Transpose of a 3x3 matrix.
-inline matrix3x3 transpose(const matrix3x3 &m) {
+constexpr matrix3x3 transpose(const matrix3x3 &m) noexcept {
     return {m.column(0), m.column(1), m.column(2)};
 }
 
 // Adjugate of a 3x3 matrix, i.e. the transpose of the cofactor matrix.
-inline matrix3x3 adjugate_matrix(const matrix3x3 &m) {
+constexpr matrix3x3 adjugate_matrix(const matrix3x3 &m) noexcept {
     // Cofactors.
     auto c0 = cross(m[1], m[2]);
     auto c1 = cross(m[2], m[0]);
@@ -134,7 +134,7 @@ inline matrix3x3 adjugate_matrix(const matrix3x3 &m) {
 }
 
 // Inverse of a 3x3 matrix or the zero matrix if `m` is non-invertible.
-inline matrix3x3 inverse_matrix(const matrix3x3 &m) {
+inline matrix3x3 inverse_matrix(const matrix3x3 &m) noexcept {
     auto det = m.determinant();
     scalar det_inv = 0;
 
@@ -146,7 +146,7 @@ inline matrix3x3 inverse_matrix(const matrix3x3 &m) {
 }
 
 // Optimized inverse for symmetric 3x3 matrices.
-inline matrix3x3 inverse_matrix_symmetric(const matrix3x3 &m) {
+constexpr matrix3x3 inverse_matrix_symmetric(const matrix3x3 &m) noexcept {
     EDYN_ASSERT(m[0][1] == m[1][0]);
     EDYN_ASSERT(m[0][2] == m[2][0]);
     EDYN_ASSERT(m[1][2] == m[2][1]);
@@ -159,7 +159,7 @@ inline matrix3x3 inverse_matrix_symmetric(const matrix3x3 &m) {
     auto a22 = m[1][1], a23 = m[1][2];
     auto a33 = m[2][2];
 
-    matrix3x3 m_inv;
+    matrix3x3 m_inv{};
 
     m_inv[0][0] = det_inv * (a22 * a33 - a23 * a23);
     m_inv[0][1] = det_inv * (a13 * a23 - a12 * a33);
@@ -177,7 +177,7 @@ inline matrix3x3 inverse_matrix_symmetric(const matrix3x3 &m) {
 }
 
 // Matrix with given vector as diagonal.
-inline matrix3x3 diagonal_matrix(const vector3 &v) {
+constexpr matrix3x3 diagonal_matrix(const vector3 &v) noexcept {
     return {
         vector3 {v.x, 0, 0},
         vector3 {0, v.y, 0},
@@ -185,12 +185,12 @@ inline matrix3x3 diagonal_matrix(const vector3 &v) {
     };
 }
 
-inline vector3 get_diagonal(const matrix3x3 &m) {
+constexpr vector3 get_diagonal(const matrix3x3 &m) noexcept {
     return {m[0][0], m[1][1], m[2][2]};
 }
 
 // Equivalent to m * diagonal_matrix(v).
-inline matrix3x3 scale_matrix(const matrix3x3 &m, const vector3 &v) {
+constexpr matrix3x3 scale_matrix(const matrix3x3 &m, const vector3 &v) noexcept {
     return {
         vector3{m.row[0].x * v.x, m.row[0].y * v.y, m.row[0].z * v.z},
         vector3{m.row[1].x * v.x, m.row[1].y * v.y, m.row[1].z * v.z},
@@ -199,7 +199,7 @@ inline matrix3x3 scale_matrix(const matrix3x3 &m, const vector3 &v) {
 }
 
 // Skew anti-symmetric matrix of a vector.
-inline matrix3x3 skew_matrix(const vector3 &v) {
+constexpr matrix3x3 skew_matrix(const vector3 &v) noexcept {
     return {
         vector3 {0, -v.z, v.y},
         vector3 {v.z, 0, -v.x},
@@ -208,7 +208,7 @@ inline matrix3x3 skew_matrix(const vector3 &v) {
 }
 
 // Converts a quaternion into a rotation matrix.
-inline matrix3x3 to_matrix3x3(const quaternion &q) {
+constexpr matrix3x3 to_matrix3x3(const quaternion &q) noexcept {
     auto d = length_sqr(q);
     auto s = 2 / d;
     auto xs = q.x * s , ys = q.y * s , zs = q.z * s ;
@@ -224,7 +224,7 @@ inline matrix3x3 to_matrix3x3(const quaternion &q) {
 }
 
 // Converts a rotation matrix into a quaternion.
-inline quaternion to_quaternion(const matrix3x3 &m) {
+inline quaternion to_quaternion(const matrix3x3 &m) noexcept {
     auto trace = m[0][0] + m[1][1] + m[2][2];
 
     if (trace > 0) {
@@ -253,7 +253,7 @@ inline quaternion to_quaternion(const matrix3x3 &m) {
 // Get XYZ Euler angles from a rotation matrix.
 // Reference: Euler Angle Formulas - David Eberly, Geometric Tools
 // https://www.geometrictools.com/Documentation/EulerAngles.pdf
-inline vector3 get_euler_angles_xyz(const matrix3x3 &m) {
+inline vector3 get_euler_angles_xyz(const matrix3x3 &m) noexcept {
     if (m[0][2] < 1) {
         if (m[0][2] > -1) {
             return {

--- a/include/edyn/math/quaternion.hpp
+++ b/include/edyn/math/quaternion.hpp
@@ -9,12 +9,12 @@ namespace edyn {
 struct quaternion {
     scalar x, y, z, w;
 
-    scalar& operator[](size_t i) {
+    scalar& operator[](size_t i) noexcept {
         EDYN_ASSERT(i < 4);
         return (&x)[i];
     }
 
-    scalar operator[](size_t i) const {
+    scalar operator[](size_t i) const noexcept {
         EDYN_ASSERT(i < 4);
         return (&x)[i];
     }
@@ -23,12 +23,12 @@ struct quaternion {
 inline constexpr quaternion quaternion_identity {0, 0, 0, 1};
 
 // Add two quaternions.
-inline quaternion operator+(const quaternion& q0, const quaternion &q1) {
+constexpr quaternion operator+(const quaternion& q0, const quaternion &q1) noexcept {
     return {q0.x + q1.x, q0.y + q1.y, q0.z + q1.z, q0.w + q1.w};
 }
 
 // Add a quaternion into another quaternion.
-inline quaternion& operator+=(quaternion &q0, const quaternion &q1) {
+constexpr quaternion& operator+=(quaternion &q0, const quaternion &q1) noexcept {
     q0.x += q1.x;
     q0.y += q1.y;
     q0.z += q1.z;
@@ -37,12 +37,12 @@ inline quaternion& operator+=(quaternion &q0, const quaternion &q1) {
 }
 
 // Subtract two quaternions.
-inline quaternion operator-(const quaternion &q0, const quaternion &q1) {
+constexpr quaternion operator-(const quaternion &q0, const quaternion &q1) noexcept {
     return {q0.x - q1.x, q0.y - q1.y, q0.z - q1.z, q0.w - q1.w};
 }
 
 // Subtract a quaternion from another quaternion.
-inline quaternion& operator-=(quaternion &q0, const quaternion &q1) {
+constexpr quaternion& operator-=(quaternion &q0, const quaternion &q1) noexcept {
     q0.x -= q1.x;
     q0.y -= q1.y;
     q0.z -= q1.z;
@@ -51,27 +51,27 @@ inline quaternion& operator-=(quaternion &q0, const quaternion &q1) {
 }
 
 // Multiply quaternion by scalar.
-inline quaternion operator*(const quaternion& q, scalar s) {
+constexpr quaternion operator*(const quaternion& q, scalar s) noexcept {
     return {q.x * s, q.y * s, q.z * s, q.w * s};
 }
 
 // Multiply scalar by quaternion.
-inline quaternion operator*(scalar s, const quaternion &q) {
+constexpr quaternion operator*(scalar s, const quaternion &q) noexcept {
     return {s * q.x, s * q.y, s * q.z, s * q.w};
 }
 
 // Divide quaternion by scalar.
-inline quaternion operator/(const quaternion &q, scalar s) {
+constexpr quaternion operator/(const quaternion &q, scalar s) noexcept {
     return {q.x / s, q.y / s, q.z / s, q.w / s};
 }
 
 // Divide scalar by quaternion.
-inline quaternion operator/(scalar s, const quaternion &q) {
+constexpr quaternion operator/(scalar s, const quaternion &q) noexcept {
     return {s / q.x, s / q.y, s / q.z, s / q.w};
 }
 
 // Product of two quaternions.
-inline quaternion operator*(const quaternion &q, const quaternion &r) {
+constexpr quaternion operator*(const quaternion &q, const quaternion &r) noexcept {
     return {
         q.w * r.x + q.x * r.w + q.y * r.z - q.z * r.y,
         q.w * r.y + q.y * r.w + q.z * r.x - q.x * r.z,
@@ -80,13 +80,13 @@ inline quaternion operator*(const quaternion &q, const quaternion &r) {
     };
 }
 
-inline quaternion & operator*=(quaternion &q, const quaternion &r) {
+constexpr quaternion& operator*=(quaternion &q, const quaternion &r) noexcept {
     return q = q * r;
 }
 
 // Product of a quaternion and vector, i.e. product of a quaternion with another
 // quaternion with a zero w component.
-inline quaternion operator*(const quaternion &q, const vector3 &v) {
+constexpr quaternion operator*(const quaternion &q, const vector3 &v) noexcept {
     return {
         q.w * v.x + q.y * v.z - q.z * v.y,
         q.w * v.y + q.z * v.x - q.x * v.z,
@@ -96,7 +96,7 @@ inline quaternion operator*(const quaternion &q, const vector3 &v) {
 }
 
 // Product of a vector and a quaternion.
-inline quaternion operator*(const vector3 &v, const quaternion &q) {
+constexpr quaternion operator*(const vector3 &v, const quaternion &q) noexcept {
     return {
         v.x * q.w + v.y * q.z - v.z * q.y,
         v.y * q.w + v.z * q.x - v.x * q.z,
@@ -106,61 +106,61 @@ inline quaternion operator*(const vector3 &v, const quaternion &q) {
 }
 
 // Check if two quaternions are equal.
-inline bool operator==(const quaternion &q, const quaternion &v) {
+constexpr bool operator==(const quaternion &q, const quaternion &v) noexcept {
     return q.x == v.x && q.y == v.y && q.z == v.z && q.w == v.w;
 }
 
 // Check if two quaternions are different.
-inline bool operator!=(const quaternion &q, const quaternion &v) {
+constexpr bool operator!=(const quaternion &q, const quaternion &v) noexcept {
     return q.x != v.x || q.y != v.y || q.z != v.z || q.w != v.w;
 }
 
 // Squared length of a quaternion.
-inline scalar length_sqr(const quaternion &q) {
+constexpr scalar length_sqr(const quaternion &q) noexcept {
     return q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
 }
 
 // Length of a quaternion.
-inline scalar length(const quaternion &q) {
+inline scalar length(const quaternion &q) noexcept {
     return std::sqrt(length_sqr(q));
 }
 
-inline scalar dot(const quaternion &q0, const quaternion &q1) {
+constexpr scalar dot(const quaternion &q0, const quaternion &q1) noexcept {
     return q0.x * q1.x + q0.y * q1.y + q0.z * q1.z + q0.w * q1.w;
 }
 
 // Returns a unit-length version of the given quaternion.
-inline quaternion normalize(const quaternion &q) {
+inline quaternion normalize(const quaternion &q) noexcept {
     auto l = length(q);
     EDYN_ASSERT(l > EDYN_EPSILON);
     return q / l;
 }
 
 // Conjugate of a quaternion.
-inline quaternion conjugate(const quaternion &q) {
+constexpr quaternion conjugate(const quaternion &q) noexcept {
     return {-q.x, -q.y, -q.z, q.w};
 }
 
 // Rotate a vector by a quaternion.
-inline vector3 rotate(const quaternion &q, const vector3 &v) {
+constexpr vector3 rotate(const quaternion &q, const vector3 &v) noexcept {
     auto r = q * v * conjugate(q);
     return {r.x, r.y, r.z};
 }
 
 // Build a quaternion from an angle about and axis of rotation.
-inline quaternion quaternion_axis_angle(const vector3 &v, scalar a) {
+inline quaternion quaternion_axis_angle(const vector3 &v, scalar a) noexcept {
     auto l = length(v);
     auto s = std::sin(a * scalar(0.5)) / l;
     return {v.x * s, v.y * s, v.z * s, std::cos(a * scalar(0.5))};
 }
 
 // Get rotation angle of a quaternion.
-inline scalar quaternion_angle(const quaternion &q) {
+inline scalar quaternion_angle(const quaternion &q) noexcept {
     return std::acos(q.w) * scalar(2);
 }
 
 // Get rotation axis of a quaternion.
-inline vector3 quaternion_axis(const quaternion &q) {
+inline vector3 quaternion_axis(const quaternion &q) noexcept {
     auto s2 = scalar(1) - q.w * q.w;
 
     if (s2 > EDYN_EPSILON) {
@@ -172,22 +172,22 @@ inline vector3 quaternion_axis(const quaternion &q) {
 }
 
 // Get x-axis of the basis of a quaternion.
-inline vector3 quaternion_x(const quaternion &q) {
+inline vector3 quaternion_x(const quaternion &q) noexcept {
     return rotate(q, vector3_x);
 }
 
 // Get y-axis of the basis of a quaternion.
-inline vector3 quaternion_y(const quaternion &q) {
+inline vector3 quaternion_y(const quaternion &q) noexcept {
     return rotate(q, vector3_y);
 }
 
 // Get z-axis of the basis of a quaternion.
-inline vector3 quaternion_z(const quaternion &q) {
+inline vector3 quaternion_z(const quaternion &q) noexcept {
     return rotate(q, vector3_z);
 }
 
 // Spherical linear interpolation.
-inline quaternion slerp(const quaternion &q0, const quaternion &q1, scalar s) {
+inline quaternion slerp(const quaternion &q0, const quaternion &q1, scalar s) noexcept {
     const auto magnitude = std::sqrt(length_sqr(q0) * length_sqr(q1));
     EDYN_ASSERT(magnitude > 0);
 
@@ -215,17 +215,17 @@ inline quaternion slerp(const quaternion &q0, const quaternion &q1, scalar s) {
 }
 
 // Integrate angular velocity over time.
-quaternion integrate(const quaternion &q, const vector3 &w, scalar dt);
+quaternion integrate(const quaternion &q, const vector3 &w, scalar dt) noexcept;
 
 // Returns the shortest rotation that takes `v0` to `v1`.
-quaternion shortest_arc(const vector3 &v0, const vector3 &v1);
+quaternion shortest_arc(const vector3 &v0, const vector3 &v1) noexcept;
 
 // Returns the angle between two quaternions along the shortest path.
-scalar angle_between(const quaternion &q0, const quaternion &q1);
+scalar angle_between(const quaternion &q0, const quaternion &q1) noexcept;
 
 // Derivative of a quaternion along an axis-angle.
 // Reference: https://fgiesen.wordpress.com/2012/08/24/quaternion-differentiation/
-inline quaternion quaternion_derivative(const quaternion &q, const vector3 &w) {
+constexpr quaternion quaternion_derivative(const quaternion &q, const vector3 &w) noexcept {
     return quaternion{w.x, w.y, w.z, 0} * q * scalar(0.5);
 }
 

--- a/include/edyn/math/transform.hpp
+++ b/include/edyn/math/transform.hpp
@@ -14,8 +14,8 @@ namespace edyn {
  * @param basis Rotation matrix in world space.
  * @return The point `p` in object space.
  */
-inline
-vector3 to_object_space(const vector3 &p, const vector3 &pos, const matrix3x3 &basis) {
+constexpr
+vector3 to_object_space(const vector3 &p, const vector3 &pos, const matrix3x3 &basis) noexcept {
     // Multiplying a vector by a matrix on the right is equivalent to multiplying
     // by the transpose of the matrix on the left, and the transpose of a rotation
     // matrix is its inverse.
@@ -29,18 +29,18 @@ vector3 to_object_space(const vector3 &p, const vector3 &pos, const matrix3x3 &b
  * @param basis Rotation matrix in world space.
  * @return The point `p` in world space.
  */
-inline
-vector3 to_world_space(const vector3 &p, const vector3 &pos, const matrix3x3 &basis) {
+constexpr
+vector3 to_world_space(const vector3 &p, const vector3 &pos, const matrix3x3 &basis) noexcept {
     return pos + basis * p;
 }
 
-inline
-vector3 to_object_space(const vector3 &p, const vector3 &pos, const quaternion &orn) {
+constexpr
+vector3 to_object_space(const vector3 &p, const vector3 &pos, const quaternion &orn) noexcept {
     return rotate(conjugate(orn), p - pos);
 }
 
-inline
-vector3 to_world_space(const vector3 &p, const vector3 &pos, const quaternion &orn) {
+constexpr
+vector3 to_world_space(const vector3 &p, const vector3 &pos, const quaternion &orn) noexcept {
     return pos + rotate(orn, p);
 }
 

--- a/include/edyn/math/vector2.hpp
+++ b/include/edyn/math/vector2.hpp
@@ -10,12 +10,12 @@ namespace edyn {
 struct vector2 {
     scalar x, y;
 
-    scalar& operator[](size_t i) {
+    scalar& operator[](size_t i) noexcept {
         EDYN_ASSERT(i < 2);
         return (&x)[i];
     }
 
-    scalar operator[](size_t i) const {
+    scalar operator[](size_t i) const noexcept {
         EDYN_ASSERT(i < 2);
         return (&x)[i];
     }
@@ -40,68 +40,68 @@ inline constexpr vector2 vector2_min {EDYN_SCALAR_MIN, EDYN_SCALAR_MIN};
 inline constexpr vector2 vector2_max {EDYN_SCALAR_MAX, EDYN_SCALAR_MAX};
 
 // Add two vectors.
-inline vector2 operator+(const vector2 &v, const vector2 &w) {
+constexpr vector2 operator+(const vector2 &v, const vector2 &w) noexcept {
     return {v.x + w.x, v.y + w.y};
 }
 
 // Add a vector into another vector.
-inline vector2& operator+=(vector2 &v, const vector2 &w) {
+constexpr vector2& operator+=(vector2 &v, const vector2 &w) noexcept {
     v.x += w.x;
     v.y += w.y;
     return v;
 }
 
 // Subtract two vectors.
-inline vector2 operator-(const vector2 &v, const vector2 &w) {
+constexpr vector2 operator-(const vector2 &v, const vector2 &w) noexcept {
     return {v.x - w.x, v.y - w.y};
 }
 
 // Subtract a vector from another vector.
-inline vector2& operator-=(vector2 &v, const vector2 &w) {
+constexpr vector2& operator-=(vector2 &v, const vector2 &w) noexcept {
     v.x -= w.x;
     v.y -= w.y;
     return v;
 }
 
 // Negation of a vector.
-inline vector2 operator-(const vector2 &v) {
+constexpr vector2 operator-(const vector2 &v) noexcept {
     return {-v.x, -v.y};
 }
 
 // Multiply vectors component-wise.
-inline vector2 operator*(const vector2 &v, const vector2 &w) {
+constexpr vector2 operator*(const vector2 &v, const vector2 &w) noexcept {
     return {v.x * w.x, v.y * w.y};
 }
 
 // Multiply vector by scalar.
-inline vector2 operator*(const vector2& v, scalar s) {
+constexpr vector2 operator*(const vector2& v, scalar s) noexcept {
     return {v.x * s, v.y * s};
 }
 
 // Multiply scalar by vector.
-inline vector2 operator*(scalar s, const vector2 &v) {
+constexpr vector2 operator*(scalar s, const vector2 &v) noexcept {
     return {s * v.x, s * v.y};
 }
 
 // Divide vector by scalar.
-inline vector2 operator/(const vector2 &v, scalar s) {
+constexpr vector2 operator/(const vector2 &v, scalar s) noexcept {
     return {v.x / s, v.y / s};
 }
 
 // Divide scalar by vector.
-inline vector2 operator/(scalar s, const vector2 &v) {
+constexpr vector2 operator/(scalar s, const vector2 &v) noexcept {
     return {s / v.x, s / v.y};
 }
 
 // Scale a vector.
-inline vector2& operator*=(vector2 &v, scalar s) {
+constexpr vector2& operator*=(vector2 &v, scalar s) noexcept {
     v.x *= s;
     v.y *= s;
     return v;
 }
 
 // Inverse-scale a vector.
-inline vector2& operator/=(vector2 &v, scalar s) {
+constexpr vector2& operator/=(vector2 &v, scalar s) noexcept {
     auto z = scalar(1) / s;
     v.x *= z;
     v.y *= z;
@@ -109,43 +109,43 @@ inline vector2& operator/=(vector2 &v, scalar s) {
 }
 
 // Dot product between vectors.
-inline scalar dot(const vector2 &v, const vector2 &w) {
+constexpr scalar dot(const vector2 &v, const vector2 &w) noexcept {
     return v.x * w.x + v.y * w.y;
 }
 
 // Dot product between a vector and a perpendicular to the other vector.
-inline scalar perp_product(const vector2 &v, const vector2 &w) {
+constexpr scalar perp_product(const vector2 &v, const vector2 &w) noexcept {
     return v.x * w.y - v.y * w.x;
 }
 
 // Vector orthogonal to argument, i.e. rotated 90 degrees counter-clockwise.
 // Negate result for a clockwise 90 degree rotation.
-inline vector2 orthogonal(const vector2 &v) {
+constexpr vector2 orthogonal(const vector2 &v) noexcept {
     return {-v.y, v.x};
 }
 
 // Square length of a vector.
-inline scalar length_sqr(const vector2 &v) {
+constexpr scalar length_sqr(const vector2 &v) noexcept {
     return dot(v, v);
 }
 
 // Length of a vector.
-inline scalar length(const vector2 &v) {
+inline scalar length(const vector2 &v) noexcept {
     return std::sqrt(length_sqr(v));
 }
 
 // Distance between two points.
-inline scalar distance(const vector2 &p0, const vector2 &p1) {
+inline scalar distance(const vector2 &p0, const vector2 &p1) noexcept {
     return length(p0 - p1);
 }
 
 // Squared distance between two points.
-inline scalar distance_sqr(const vector2 &p0, const vector2 &p1) {
+constexpr scalar distance_sqr(const vector2 &p0, const vector2 &p1) noexcept {
     return length_sqr(p0 - p1);
 }
 
 // Normalized vector (unit length). Asserts if the vector's length is zero.
-inline vector2 normalize(const vector2 &v) {
+inline vector2 normalize(const vector2 &v) noexcept {
     auto l = length(v);
     EDYN_ASSERT(l > EDYN_EPSILON);
     return v / l;

--- a/include/edyn/math/vector2_3_util.hpp
+++ b/include/edyn/math/vector2_3_util.hpp
@@ -9,54 +9,54 @@ namespace edyn {
 // Series of functions to project a `vector3` into a coordinate plane and 
 // return that as a `vector2`.
 
-inline vector2 to_vector2_xy(const vector3 &v) {
+constexpr vector2 to_vector2_xy(const vector3 &v) noexcept {
     return {v.x, v.y};
 }
 
-inline vector2 to_vector2_xz(const vector3 &v) {
+constexpr vector2 to_vector2_xz(const vector3 &v) noexcept {
     return {v.x, v.z};
 }
 
-inline vector2 to_vector2_yz(const vector3 &v) {
+constexpr vector2 to_vector2_yz(const vector3 &v) noexcept {
     return {v.y, v.z};
 }
 
-inline vector2 to_vector2_zy(const vector3 &v) {
+constexpr vector2 to_vector2_zy(const vector3 &v) noexcept {
     return {v.z, v.y};
 }
 
-inline vector2 to_vector2_yx(const vector3 &v) {
+constexpr vector2 to_vector2_yx(const vector3 &v) noexcept {
     return {v.y, v.x};
 }
 
-inline vector2 to_vector2_zx(const vector3 &v) {
+constexpr vector2 to_vector2_zx(const vector3 &v) noexcept {
     return {v.z, v.x};
 }
 
 // Series of functions to convert a `vector2` into a `vector3` contained in a
 // coordinate plane.
 
-inline vector3 to_vector3_xy(const vector2 &v) {
+constexpr vector3 to_vector3_xy(const vector2 &v) noexcept {
     return {v.x, v.y, 0};
 }
 
-inline vector3 to_vector3_xz(const vector2 &v) {
+constexpr vector3 to_vector3_xz(const vector2 &v) noexcept {
     return {v.x, 0, v.y};
 }
 
-inline vector3 to_vector3_yz(const vector2 &v) {
+constexpr vector3 to_vector3_yz(const vector2 &v) noexcept {
     return {0, v.x, v.y};
 }
 
-inline vector3 to_vector3_zy(const vector2 &v) {
+constexpr vector3 to_vector3_zy(const vector2 &v) noexcept {
     return {0, v.y, v.x};
 }
 
-inline vector3 to_vector3_yx(const vector2 &v) {
+constexpr vector3 to_vector3_yx(const vector2 &v) noexcept {
     return {v.y, v.x, 0};
 }
 
-inline vector3 to_vector3_zx(const vector2 &v) {
+constexpr vector3 to_vector3_zx(const vector2 &v) noexcept {
     return {v.y, 0, v.x};
 }
 

--- a/include/edyn/math/vector3.hpp
+++ b/include/edyn/math/vector3.hpp
@@ -11,12 +11,12 @@ namespace edyn {
 struct vector3 {
     scalar x, y, z;
 
-    scalar& operator[](size_t i) {
+    scalar& operator[](size_t i) noexcept {
         EDYN_ASSERT(i < 3);
         return (&x)[i];
     }
 
-    scalar operator[](size_t i) const {
+    scalar operator[](size_t i) const noexcept {
         EDYN_ASSERT(i < 3);
         return (&x)[i];
     }
@@ -44,12 +44,12 @@ inline constexpr vector3 vector3_min {EDYN_SCALAR_MIN, EDYN_SCALAR_MIN, EDYN_SCA
 inline constexpr vector3 vector3_max {EDYN_SCALAR_MAX, EDYN_SCALAR_MAX, EDYN_SCALAR_MAX};
 
 // Add two vectors.
-inline vector3 operator+(const vector3 &v, const vector3 &w) {
+constexpr vector3 operator+(const vector3 &v, const vector3 &w) noexcept {
     return {v.x + w.x, v.y + w.y, v.z + w.z};
 }
 
 // Add a vector into another vector.
-inline vector3& operator+=(vector3 &v, const vector3 &w) {
+constexpr vector3& operator+=(vector3 &v, const vector3 &w) noexcept {
     v.x += w.x;
     v.y += w.y;
     v.z += w.z;
@@ -57,12 +57,12 @@ inline vector3& operator+=(vector3 &v, const vector3 &w) {
 }
 
 // Subtract two vectors.
-inline vector3 operator-(const vector3 &v, const vector3 &w) {
+constexpr vector3 operator-(const vector3 &v, const vector3 &w) noexcept {
     return {v.x - w.x, v.y - w.y, v.z - w.z};
 }
 
 // Subtract a vector from another vector.
-inline vector3& operator-=(vector3 &v, const vector3 &w) {
+constexpr vector3& operator-=(vector3 &v, const vector3 &w) noexcept {
     v.x -= w.x;
     v.y -= w.y;
     v.z -= w.z;
@@ -70,37 +70,37 @@ inline vector3& operator-=(vector3 &v, const vector3 &w) {
 }
 
 // Negation of a vector.
-inline vector3 operator-(const vector3 &v) {
+constexpr vector3 operator-(const vector3 &v) noexcept {
     return {-v.x, -v.y, -v.z};
 }
 
 // Multiply vectors component-wise.
-inline vector3 operator*(const vector3 &v, const vector3 &w) {
+constexpr vector3 operator*(const vector3 &v, const vector3 &w) noexcept {
     return {v.x * w.x, v.y * w.y, v.z * w.z};
 }
 
 // Multiply vector by scalar.
-inline constexpr vector3 operator*(const vector3& v, scalar s) {
+constexpr vector3 operator*(const vector3& v, scalar s) noexcept {
     return {v.x * s, v.y * s, v.z * s};
 }
 
 // Multiply scalar by vector.
-inline vector3 operator*(scalar s, const vector3 &v) {
+constexpr vector3 operator*(scalar s, const vector3 &v) noexcept {
     return {s * v.x, s * v.y, s * v.z};
 }
 
 // Divide vector by scalar.
-inline vector3 operator/(const vector3 &v, scalar s) {
+constexpr vector3 operator/(const vector3 &v, scalar s) noexcept {
     return {v.x / s, v.y / s, v.z / s};
 }
 
 // Divide scalar by vector.
-inline vector3 operator/(scalar s, const vector3 &v) {
+constexpr vector3 operator/(scalar s, const vector3 &v) noexcept {
     return {s / v.x, s / v.y, s / v.z};
 }
 
 // Scale a vector.
-inline vector3 & operator*=(vector3 &v, scalar s) {
+constexpr vector3& operator*=(vector3 &v, scalar s) noexcept {
     v.x *= s;
     v.y *= s;
     v.z *= s;
@@ -108,7 +108,7 @@ inline vector3 & operator*=(vector3 &v, scalar s) {
 }
 
 // Inverse-scale a vector.
-inline vector3 & operator/=(vector3 &v, scalar s) {
+constexpr vector3& operator/=(vector3 &v, scalar s) noexcept {
     auto z = scalar(1) / s;
     v.x *= z;
     v.y *= z;
@@ -117,7 +117,7 @@ inline vector3 & operator/=(vector3 &v, scalar s) {
 }
 
 // Multiply vectors component-wise and assign to the first.
-inline vector3 & operator*=(vector3 &v, const vector3 &w) {
+constexpr vector3& operator*=(vector3 &v, const vector3 &w) noexcept {
     v.x *= w.x;
     v.y *= w.y;
     v.z *= w.z;
@@ -125,42 +125,42 @@ inline vector3 & operator*=(vector3 &v, const vector3 &w) {
 }
 
 // Check if two vectors are equal.
-inline bool operator==(const vector3 &v, const vector3 &w) {
+constexpr bool operator==(const vector3 &v, const vector3 &w) noexcept {
     return v.x == w.x && v.y == w.y && v.z == w.z;
 }
 
 // Check if two vectors are different.
-inline bool operator!=(const vector3 &v, const vector3 &w) {
+constexpr bool operator!=(const vector3 &v, const vector3 &w) noexcept {
     return v.x != w.x || v.y != w.y || v.z != w.z;
 }
 
 // Check if a vector is bigger than another component-wise.
-inline bool operator>(const vector3 &v, const vector3 &w) {
+constexpr bool operator>(const vector3 &v, const vector3 &w) noexcept {
     return v.x > w.x && v.y > w.y && v.z > w.z;
 }
 
 // Check if a vector is smaller than another component-wise.
-inline bool operator<(const vector3 &v, const vector3 &w) {
+constexpr bool operator<(const vector3 &v, const vector3 &w) noexcept {
     return v.x < w.x && v.y < w.y && v.z < w.z;
 }
 
 // Check if a vector is greater than or equal to another component-wise.
-inline bool operator>=(const vector3 &v, const vector3 &w) {
+constexpr bool operator>=(const vector3 &v, const vector3 &w) noexcept {
     return v.x >= w.x && v.y >= w.y && v.z >= w.z;
 }
 
 // Check if a vector is less than or equal to another component-wise.
-inline bool operator<=(const vector3 &v, const vector3 &w) {
+constexpr bool operator<=(const vector3 &v, const vector3 &w) noexcept {
     return v.x <= w.x && v.y <= w.y && v.z <= w.z;
 }
 
 // Dot product between vectors.
-inline scalar dot(const vector3 &v, const vector3 &w) {
+constexpr scalar dot(const vector3 &v, const vector3 &w) noexcept {
     return v.x * w.x + v.y * w.y + v.z * w.z;
 }
 
 // Cross product between two vectors.
-inline vector3 cross(const vector3 &v, const vector3 &w) {
+constexpr vector3 cross(const vector3 &v, const vector3 &w) noexcept {
     return {v.y * w.z - v.z * w.y,
             v.z * w.x - v.x * w.z,
             v.x * w.y - v.y * w.x};
@@ -168,42 +168,42 @@ inline vector3 cross(const vector3 &v, const vector3 &w) {
 
 // Triple product among three vectors, i.e. the dot product of one of
 // them with the cross product of the other two.
-inline scalar triple_product(const vector3 &u,
+constexpr scalar triple_product(const vector3 &u,
                              const vector3 &v,
-                             const vector3 &w) {
+                             const vector3 &w) noexcept {
     return dot(u, cross(v, w));
 }
 
 // Square length of a vector.
-inline scalar length_sqr(const vector3 &v) {
+constexpr scalar length_sqr(const vector3 &v) noexcept {
     return dot(v, v);
 }
 
 // Length of a vector.
-inline scalar length(const vector3 &v) {
+inline scalar length(const vector3 &v) noexcept {
     return std::sqrt(length_sqr(v));
 }
 
 // Distance between two points.
-inline scalar distance(const vector3 &p0, const vector3 &p1) {
+inline scalar distance(const vector3 &p0, const vector3 &p1) noexcept {
     return length(p0 - p1);
 }
 
 // Squared distance between two points.
-inline scalar distance_sqr(const vector3 &p0, const vector3 &p1) {
+constexpr scalar distance_sqr(const vector3 &p0, const vector3 &p1) noexcept {
     return length_sqr(p0 - p1);
 }
 
 // Normalized vector (unit length). Asserts if the vector's length is zero.
-inline vector3 normalize(const vector3 &v) {
+inline vector3 normalize(const vector3 &v) noexcept {
     auto l = length(v);
     EDYN_ASSERT(l > EDYN_EPSILON);
     return v / l;
 }
 
 // Normalizes vector if it's length is greater than a threshold above zero.
-// Returns where the vector was normalized.
-inline bool try_normalize(vector3 &v) {
+// Returns true if the vector was normalized.
+inline bool try_normalize(vector3 &v) noexcept {
     auto lsqr = length_sqr(v);
 
     if (lsqr > EDYN_EPSILON) {
@@ -215,32 +215,32 @@ inline bool try_normalize(vector3 &v) {
 }
 
 // Projects direction vector `v` onto plane with normal `n`.
-inline vector3 project_direction(const vector3 &v, const vector3 &n) {
+constexpr vector3 project_direction(const vector3 &v, const vector3 &n) noexcept {
     return v - n * dot(v, n);
 }
 
 // Projects point `p` onto plane with origin `q` and normal `n`.
-inline vector3 project_plane(const vector3 &p, const vector3 &q, const vector3 &n) {
+constexpr vector3 project_plane(const vector3 &p, const vector3 &q, const vector3 &n) noexcept {
     return p - n * dot(p - q, n);
 }
 
 // Performs element-wise minimum.
-inline vector3 min(const vector3 &v, const vector3 &w) {
+constexpr vector3 min(const vector3 &v, const vector3 &w) noexcept {
     return {std::min(v.x, w.x), std::min(v.y, w.y), std::min(v.z, w.z)};
 }
 
 // Performs element-wise maximum.
-inline vector3 max(const vector3 &v, const vector3 &w) {
+constexpr vector3 max(const vector3 &v, const vector3 &w) noexcept {
     return {std::max(v.x, w.x), std::max(v.y, w.y), std::max(v.z, w.z)};
 }
 
 // Performs element-wise absolute.
-inline vector3 abs(const vector3 &v) {
+inline vector3 abs(const vector3 &v) noexcept {
     return {std::abs(v.x), std::abs(v.y), std::abs(v.z)};
 }
 
 // Returns the index of the coordinate with greatest value.
-inline size_t max_index(const vector3 &v) {
+constexpr size_t max_index(const vector3 &v) noexcept {
     auto max_val = v.x;
     size_t max_idx = 0;
 
@@ -257,7 +257,7 @@ inline size_t max_index(const vector3 &v) {
 }
 
 // Returns the index of the coordinate with greatest absolute value.
-inline size_t max_index_abs(const vector3 &v) {
+inline size_t max_index_abs(const vector3 &v) noexcept {
     return max_index(abs(v));
 }
 

--- a/src/edyn/math/geom.cpp
+++ b/src/edyn/math/geom.cpp
@@ -9,7 +9,7 @@
 namespace edyn {
 
 scalar closest_point_segment(const vector3 &q0, const vector3 &q1,
-                             const vector3 &p, scalar &t, vector3 &q) {
+                             const vector3 &p, scalar &t, vector3 &q) noexcept {
     auto v = q1 - q0; // Direction vector of segment `q`.
     auto w = p - q0; // Vector from initial point of segment to point `p`.
     auto a = dot(w, v);
@@ -21,7 +21,7 @@ scalar closest_point_segment(const vector3 &q0, const vector3 &q1,
 }
 
 scalar distance_sqr_line(const vector3 &q0, const vector3 &dir,
-                         const vector3 &p) {
+                         const vector3 &p) noexcept {
     auto w = p - q0;
     auto a = dot(w, dir);
     auto b = dot(dir, dir);
@@ -32,7 +32,7 @@ scalar distance_sqr_line(const vector3 &q0, const vector3 &dir,
 }
 
 scalar closest_point_line(const vector3 &q0, const vector3 &dir,
-                          const vector3 &p, scalar &t, vector3 &r) {
+                          const vector3 &p, scalar &t, vector3 &r) noexcept {
     auto w = p - q0; // Vector from initial point of line to point `p`.
     auto a = dot(w, dir);
     auto b = dot(dir, dir);
@@ -44,7 +44,7 @@ scalar closest_point_line(const vector3 &q0, const vector3 &dir,
 
 bool closest_point_line_line(const vector3 &p1, const vector3 &q1,
                              const vector3 &p2, const vector3 &q2,
-                             scalar &s, scalar &t) {
+                             scalar &s, scalar &t) noexcept {
     // Reference: Real-Time Collision Detection - Christer Ericson,
     // Section 5.1.8 - Closest Points of Two Lines
     auto d1 = q1 - p1;
@@ -75,7 +75,7 @@ scalar closest_point_segment_segment(const vector3 &p1, const vector3 &q1,
                                      vector3 &c1, vector3 &c2,
                                      size_t *num_points,
                                      scalar *sp, scalar *tp,
-                                     vector3 *c1p, vector3 *c2p) {
+                                     vector3 *c1p, vector3 *c2p) noexcept {
     const auto d1 = q1 - p1; // Direction vector of segment `s1`.
     const auto d2 = q2 - p2; // Direction vector of segment `s2`.
     const auto r = p1 - p2;
@@ -169,7 +169,7 @@ scalar closest_point_segment_segment(const vector3 &p1, const vector3 &q1,
 }
 
 scalar closest_point_disc(const vector3 &dpos, const quaternion &dorn,
-                          scalar radius, const vector3 &p, vector3 &q) {
+                          scalar radius, const vector3 &p, vector3 &q) noexcept {
     // Project point onto disc's plane.
     const auto normal = rotate(dorn, vector3_x);
     const auto ln = dot(p - dpos, normal);
@@ -190,7 +190,7 @@ scalar closest_point_disc(const vector3 &dpos, const quaternion &dorn,
 }
 
 size_t intersect_line_circle(const vector2 &p0, const vector2 &p1,
-                             scalar radius, scalar &s0, scalar &s1) {
+                             scalar radius, scalar &s0, scalar &s1) noexcept {
     auto d = p1 - p0;
     auto dl2 = length_sqr(d);
     auto dp = dot(d, p0);
@@ -217,7 +217,7 @@ scalar closest_point_circle_line(
     const vector3 &p0, const vector3 &p1, size_t &num_points,
     scalar &s0, vector3 &rc0, vector3 &rl0,
     scalar &s1, vector3 &rc1, vector3 &rl1,
-    vector3 &normal, scalar /*threshold*/) {
+    vector3 &normal, scalar /*threshold*/) noexcept {
 
     // Line points in local disc space. The face of the disc points towards
     // the positive x-axis.
@@ -394,7 +394,7 @@ scalar closest_point_circle_line(
 
 size_t intersect_circle_circle(const vector2 &posA, scalar radiusA,
                                const vector2 &posB, scalar radiusB,
-                               vector2 &res0, vector2 &res1) {
+                               vector2 &res0, vector2 &res1) noexcept {
     // Reference: Intersection of Linear and Circular Components in 2D - David Eberly
     // https://www.geometrictools.com/Documentation/IntersectionLine2Circle2.pdf
     auto u = posB - posA;
@@ -647,7 +647,7 @@ bool intersect_aabb(const vector3 &min0, const vector3 &max0,
 }
 
 vector3 support_point_circle(const vector3 &pos, const quaternion &orn,
-                             scalar radius, const vector3 &dir) {
+                             scalar radius, const vector3 &dir) noexcept {
     auto local_dir = rotate(conjugate(orn), dir);
     // Squared length in yz plane.
     auto len_yz_sqr = local_dir.y * local_dir.y + local_dir.z * local_dir.z;
@@ -709,7 +709,7 @@ size_t intersect_segments(const vector2 &p0, const vector2 &p1,
     return 0;
 }
 
-scalar area_4_points(const vector3 &p0, const vector3 &p1, const vector3 &p2, const vector3 &p3) {
+scalar area_4_points(const vector3 &p0, const vector3 &p1, const vector3 &p2, const vector3 &p3) noexcept {
 	vector3 a[3], b[3];
 	a[0] = p0 - p1;
 	a[1] = p0 - p2;
@@ -730,7 +730,7 @@ insertion_point_result insertion_point_index(const vector3 *points,
                                              size_t count,
                                              size_t &num_points,
                                              const vector3 &new_point,
-                                             scalar new_point_depth) {
+                                             scalar new_point_depth) noexcept {
     EDYN_ASSERT(num_points <= count);
     const auto max_dist_similar_sqr = contact_merging_threshold * contact_merging_threshold;
 
@@ -845,7 +845,7 @@ insertion_point_result insertion_point_index(const vector3 *points,
     return {point_insertion_type::none, count};
 }
 
-vector3 closest_point_box_outside(const vector3 &half_extent, const vector3 &p) {
+vector3 closest_point_box_outside(const vector3 &half_extent, const vector3 &p) noexcept {
     auto closest = p;
     closest.x = std::min(half_extent.x, closest.x);
     closest.x = std::max(-half_extent.x, closest.x);
@@ -856,7 +856,7 @@ vector3 closest_point_box_outside(const vector3 &half_extent, const vector3 &p) 
     return closest;
 }
 
-scalar closest_point_box_inside(const vector3 &half_extent, const vector3 &p, vector3 &closest, vector3 &normal) {
+scalar closest_point_box_inside(const vector3 &half_extent, const vector3 &p, vector3 &closest, vector3 &normal) noexcept {
     EDYN_ASSERT(p >= -half_extent && p <= half_extent);
 
     auto dist = half_extent.x - p.x;
@@ -904,7 +904,7 @@ scalar closest_point_box_inside(const vector3 &half_extent, const vector3 &p, ve
 
 size_t intersect_line_aabb(const vector2 &p0, const vector2 &p1,
                            const vector2 &aabb_min, const vector2 &aabb_max,
-                           scalar &s0, scalar &s1) {
+                           scalar &s0, scalar &s1) noexcept {
     size_t num_points = 0;
     auto d = p1 - p0;
     auto e = aabb_min - p0;
@@ -1000,7 +1000,7 @@ size_t intersect_line_aabb(const vector2 &p0, const vector2 &p1,
 
 bool point_in_polygonal_prism(const std::vector<vector3> &vertices,
                               const std::vector<size_t> &indices,
-                              const vector3 &normal, const vector3 &point) {
+                              const vector3 &normal, const vector3 &point) noexcept {
     const auto count = indices.size();
     EDYN_ASSERT(count > 2);
 
@@ -1044,7 +1044,7 @@ bool point_in_polygonal_prism(const std::vector<vector3> &vertices,
 // Reference: Real-Time Collision Detection - Christer Ericson,
 // Section 5.3.3 - Intersecting Ray or Segment Against Box.
 bool intersect_segment_aabb(vector3 p0, vector3 p1,
-                            vector3 aabb_min, vector3 aabb_max) {
+                            vector3 aabb_min, vector3 aabb_max) noexcept {
     auto aabb_center = (aabb_min + aabb_max) * scalar(0.5);
     auto half_extents = aabb_max - aabb_center;
     auto midpoint = (p0 + p1) * scalar(0.5);
@@ -1083,7 +1083,7 @@ bool intersect_segment_aabb(vector3 p0, vector3 p1,
     return true;
 }
 
-intersect_ray_cylinder_result intersect_ray_cylinder(vector3 p0, vector3 p1, vector3 pos, quaternion orn, scalar radius, scalar half_length, scalar &u) {
+intersect_ray_cylinder_result intersect_ray_cylinder(vector3 p0, vector3 p1, vector3 pos, quaternion orn, scalar radius, scalar half_length, scalar &u) noexcept {
     // Let a plane be defined by the ray and the vector orthogonal to the
     // cylinder axis and the ray (i.e. their cross product). This plane cuts
     // the cylinder and their intersection is an ellipse with vertical half
@@ -1126,7 +1126,7 @@ intersect_ray_cylinder_result intersect_ray_cylinder(vector3 p0, vector3 p1, vec
     return {intersect_ray_cylinder_result::kind::intersects, dist_sqr, normal};
 }
 
-bool intersect_ray_sphere(vector3 p0, vector3 p1, vector3 pos, scalar radius, scalar &t) {
+bool intersect_ray_sphere(vector3 p0, vector3 p1, vector3 pos, scalar radius, scalar &t) noexcept {
     // Reference: Real-Time Collision Detection - Christer Ericson,
     // Section 5.3.2 - Intersecting Ray or Segment Against Sphere.
     // Substitute parametrized line function into sphere equation and
@@ -1159,7 +1159,7 @@ bool intersect_ray_sphere(vector3 p0, vector3 p1, vector3 pos, scalar radius, sc
 
 bool intersect_segment_triangle(const vector3 &p0, const vector3 &p1,
                                 const std::array<vector3, 3> &vertices,
-                                const vector3 &normal, scalar &t) {
+                                const vector3 &normal, scalar &t) noexcept {
     auto d = dot(p1 - p0, normal);
     auto e = dot(vertices[0] - p0, normal);
     t = 0;

--- a/src/edyn/math/quaternion.cpp
+++ b/src/edyn/math/quaternion.cpp
@@ -4,7 +4,7 @@
 namespace edyn {
 
 // "Practical Parameterization of Rotations Using the Exponential Map", F. Sebastian Grassia
-quaternion integrate(const quaternion &q, const vector3 &w, scalar dt) {
+quaternion integrate(const quaternion &q, const vector3 &w, scalar dt) noexcept {
     const auto ws = length(w);
     const auto min_ws = scalar(0.001);
     constexpr auto half = scalar(0.5);
@@ -22,7 +22,7 @@ quaternion integrate(const quaternion &q, const vector3 &w, scalar dt) {
 }
 
 // Bullet Physics (btQuaternion.h), Game Programming Gems 2.10.
-quaternion shortest_arc(const vector3 &v0, const vector3 &v1) {
+quaternion shortest_arc(const vector3 &v0, const vector3 &v1) noexcept {
     auto c = cross(v0, v1);
     auto d = dot(v0, v1);
 
@@ -37,7 +37,7 @@ quaternion shortest_arc(const vector3 &v0, const vector3 &v1) {
     return normalize(quaternion{c.x * rs, c.y * rs, c.z * rs, s * scalar(0.5)});
 }
 
-scalar angle_between(const quaternion &q0, const quaternion &q1) {
+scalar angle_between(const quaternion &q0, const quaternion &q1) noexcept {
     auto s = std::sqrt(length_sqr(q0) * length_sqr(q1));
     EDYN_ASSERT(std::abs(s) > EDYN_EPSILON);
     auto d = dot(q0, q1);


### PR DESCRIPTION
Sprinkled `constexpr` and `noexcept` where possible.

Due to C++17 limitations the following couldn't be made `constexpr`:
- `vector2` & `vector3`'s `operator[]`: doing pointer arithmetic like this is technically UB, but in C++20 these can be worked around using `std::is_constant_evaluated`.
- functions using `cmath`'s math operations, such as `std::sqrt` & `std::abs`: these are constexpr since C++23, and they most likely have compiler support now days, we still can't use them due to being C++23 sadly.
- some functions in `edyn/math/geom.hpp` (like `edyn::closest_point_segment`) could perfectly be made constexpr by defining them inline instead of in a separated transaction unit, but i don't think that's something i should change