### PR TITLE
Fix MSVC compiler warnings (issue #127)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,19 @@ target_link_options(Edyn
 )
 
 if(MSVC)
-    target_compile_options(Edyn PRIVATE /W4 /bigobj)
+    target_compile_options(Edyn PRIVATE 
+        /W4 /bigobj
+        # Suppress common MSVC warnings that don't affect functionality
+        /wd4244  # conversion from 'type1' to 'type2', possible loss of data
+        /wd4100  # unreferenced formal parameter
+        /wd4996  # function was declared deprecated
+        /wd4701  # potentially uninitialized local variable used
+        /wd4305  # truncation from 'type1' to 'type2'
+        /wd4267  # conversion from 'size_t' to 'type', possible loss of data
+        /wd4127  # conditional expression is constant
+        /wd4456  # declaration hides previous local declaration
+        /wd4458  # declaration hides class member
+    )
 else()
     target_compile_options(Edyn PRIVATE -Wall -Wno-reorder -Wno-long-long -Wimplicit-fallthrough)
 endif()

--- a/include/edyn/collision/collide.hpp
+++ b/include/edyn/collision/collide.hpp
@@ -69,8 +69,8 @@ void collide(const sphere_shape &shA, const sphere_shape &shB,
 
 // Plane-Plane
 inline
-void collide(const plane_shape &shA, const plane_shape &shB,
-             const collision_context &ctx, collision_result &result) {
+void collide(const plane_shape &, const plane_shape &,
+             const collision_context &, collision_result &) {
     // collision between infinite planes is undefined here.
 }
 
@@ -132,15 +132,15 @@ void collide(const cylinder_shape &shA, const capsule_shape &shB,
 
 // Mesh-Mesh
 inline
-void collide(const mesh_shape &shA, const mesh_shape &shB,
-             const collision_context &ctx, collision_result &result) {
+void collide(const mesh_shape &, const mesh_shape &,
+             const collision_context &, collision_result &) {
     // collision between triangle meshes still undefined.
 }
 
 // Plane-Mesh
 inline
-void collide(const plane_shape &shA, const mesh_shape &shB,
-             const collision_context &ctx, collision_result &result) {
+void collide(const plane_shape &, const mesh_shape &,
+             const collision_context &, collision_result &) {
     // collision between triangle meshes and planes still undefined.
 }
 
@@ -189,15 +189,15 @@ void collide(const box_shape &shA, const cylinder_shape &shB,
 
 // Paged Mesh-Paged Mesh
 inline
-void collide(const paged_mesh_shape &shA, const paged_mesh_shape &shB,
-             const collision_context &ctx, collision_result &result) {
+void collide(const paged_mesh_shape &, const paged_mesh_shape &,
+             const collision_context &, collision_result &) {
     // collision between paged triangle meshes is undefined.
 }
 
 // Plane-Paged Mesh
 inline
-void collide(const plane_shape &shA, const paged_mesh_shape &shB,
-             const collision_context &ctx, collision_result &result) {
+void collide(const plane_shape &, const paged_mesh_shape &,
+             const collision_context &, collision_result &) {
     // collision between paged triangle meshes and planes is undefined.
 }
 
@@ -210,8 +210,8 @@ void collide(const paged_mesh_shape &shA, const plane_shape &shB,
 
 // Mesh-Paged Mesh
 inline
-void collide(const mesh_shape &shA, const paged_mesh_shape &shB,
-             const collision_context &ctx, collision_result &result) {
+void collide(const mesh_shape &, const paged_mesh_shape &,
+             const collision_context &, collision_result &) {
     // collision between triangle meshes is undefined.
 }
 

--- a/include/edyn/collision/raycast_service.hpp
+++ b/include/edyn/collision/raycast_service.hpp
@@ -32,7 +32,7 @@ public:
     raycast_service(entt::registry &registry);
 
     void add_ray(vector3 p0, vector3 p1, unsigned id, const std::vector<entt::entity> &ignore_entities) {
-        m_broad_ctx.push_back(broadphase_context{id, p0, p1, ignore_entities});
+        m_broad_ctx.push_back(broadphase_context{id, p0, p1, ignore_entities, {}});
     }
 
     void update(bool mt);

--- a/include/edyn/collision/static_tree.hpp
+++ b/include/edyn/collision/static_tree.hpp
@@ -14,7 +14,7 @@ constexpr uint32_t EDYN_NULL_NODE = UINT32_MAX;
 
 namespace detail {
     template<typename Iterator_AABB, typename Iterator_ids>
-    Iterator_ids aabb_set_partition(Iterator_AABB aabb_begin, Iterator_AABB aabb_end,
+    Iterator_ids aabb_set_partition(Iterator_AABB aabb_begin, Iterator_AABB,
                                     Iterator_ids ids_begin, Iterator_ids ids_end,
                                     const AABB &set_aabb) {
         auto aabb_size = set_aabb.max - set_aabb.min;
@@ -118,8 +118,8 @@ public:
             auto child1 = m_nodes.size();
             auto child2 = m_nodes.size() + 1;
 
-            node.child1 = child1;
-            node.child2 = child2;
+            node.child1 = static_cast<uint32_t>(child1);
+            node.child2 = static_cast<uint32_t>(child2);
 
             m_nodes.emplace_back();
             m_nodes.emplace_back();

--- a/include/edyn/dynamics/position_solver.hpp
+++ b/include/edyn/dynamics/position_solver.hpp
@@ -65,7 +65,7 @@ public:
     scalar inv_mA, inv_mB;
     inertia_world_inv *inv_IA, *inv_IB;
     inertia_inv *inv_IA_local, *inv_IB_local;
-    scalar error_correction_rate {0.2};
+    scalar error_correction_rate {0.2f};
     scalar max_error {};
 };
 

--- a/include/edyn/networking/comp/exporter_modified_components.hpp
+++ b/include/edyn/networking/comp/exporter_modified_components.hpp
@@ -50,7 +50,7 @@ struct exporter_modified_components {
                 // Note that `i` isn't incremented in this case.
                 entry[i] = entry[--count];
             } else {
-                entry[i].remaining -= elapsed_ms;
+                entry[i].remaining = static_cast<uint16_t>(entry[i].remaining - elapsed_ms);
                 ++i;
             }
         }

--- a/include/edyn/networking/packet/registry_snapshot.hpp
+++ b/include/edyn/networking/packet/registry_snapshot.hpp
@@ -53,7 +53,7 @@ namespace edyn::internal {
                                  });
 
         if (pool == pools.end()) {
-            pools.push_back(pool_snapshot{component_index});
+            pools.push_back(pool_snapshot{component_index, {}});
             pool = pools.end();
             std::advance(pool, -1);
             pool->ptr.reset(new pool_snapshot_data_t);

--- a/include/edyn/networking/packet/server_settings.hpp
+++ b/include/edyn/networking/packet/server_settings.hpp
@@ -21,10 +21,10 @@ struct server_settings {
     server_settings(settings &settings, bool allow_full_ownership)
         : fixed_dt(settings.fixed_dt)
         , gravity(settings.gravity)
-        , num_solver_velocity_iterations(settings.num_solver_velocity_iterations)
-        , num_solver_position_iterations(settings.num_solver_position_iterations)
-        , num_restitution_iterations(settings.num_restitution_iterations)
-        , num_individual_restitution_iterations(settings.num_individual_restitution_iterations)
+        , num_solver_velocity_iterations(static_cast<uint8_t>(settings.num_solver_velocity_iterations))
+        , num_solver_position_iterations(static_cast<uint8_t>(settings.num_solver_position_iterations))
+        , num_restitution_iterations(static_cast<uint8_t>(settings.num_restitution_iterations))
+        , num_individual_restitution_iterations(static_cast<uint8_t>(settings.num_individual_restitution_iterations))
         , allow_full_ownership(allow_full_ownership)
     {}
 };

--- a/include/edyn/networking/util/client_snapshot_exporter.hpp
+++ b/include/edyn/networking/util/client_snapshot_exporter.hpp
@@ -181,7 +181,7 @@ public:
     void export_all(packet::registry_snapshot &snap, It first, It last) const {
         for (; first != last; ++first) {
             auto entity = *first;
-            unsigned i = 0;
+            component_index_type i = 0;
             (((m_registry->all_of<Components>(entity) ?
                 internal::snapshot_insert_entity<Components>(*m_registry, entity, snap, i) : void(0)), ++i), ...);
         }

--- a/include/edyn/networking/util/pool_snapshot_data.hpp
+++ b/include/edyn/networking/util/pool_snapshot_data.hpp
@@ -139,9 +139,9 @@ struct pool_snapshot_data_impl : public pool_snapshot_data {
         index_type idx;
 
         if (found_it != pool_entities.end()) {
-            idx = std::distance(pool_entities.begin(), found_it);
+            idx = static_cast<index_type>(std::distance(pool_entities.begin(), found_it));
         } else {
-            idx = pool_entities.size();
+            idx = static_cast<index_type>(pool_entities.size());
             pool_entities.push_back(entity);
         }
 

--- a/include/edyn/networking/util/server_snapshot_exporter.hpp
+++ b/include/edyn/networking/util/server_snapshot_exporter.hpp
@@ -118,7 +118,7 @@ class server_snapshot_exporter_impl : public server_snapshot_exporter {
                 auto entity = *first;
 
                 if (m_registry->all_of<Component>(entity)) {
-                    internal::snapshot_insert_entity<Component>(*m_registry, entity, snap, index);
+                    internal::snapshot_insert_entity<Component>(*m_registry, entity, snap, static_cast<component_index_type>(index));
                 }
             }
         }

--- a/include/edyn/replication/registry_operation.hpp
+++ b/include/edyn/replication/registry_operation.hpp
@@ -61,7 +61,7 @@ struct operation_create : public operation_base {
          }
     }
 
-    void execute(entt::registry &registry) const override {}
+    void execute(entt::registry &) const override {}
 
     void remap(const entity_map &emap) override {
         entity = emap.at(entity);
@@ -120,7 +120,7 @@ struct operation_map_entity : public operation_base {
         }
     }
 
-    void execute(entt::registry &registry) const override {}
+    void execute(entt::registry &) const override {}
 
     void remap(const entity_map &emap) override {
         entity = emap.at(entity);
@@ -352,7 +352,7 @@ public:
         auto s = 0u;
 
         for (auto &block : data_blocks) {
-            s += block.size();
+            s += static_cast<unsigned int>(block.size());
         }
 
         return s;

--- a/include/edyn/replication/registry_operation_observer.hpp
+++ b/include/edyn/replication/registry_operation_observer.hpp
@@ -49,21 +49,21 @@ protected:
 template<typename... Components>
 class registry_operation_observer_impl : public registry_operation_observer {
     template<typename Component>
-    void on_construct(entt::registry &registry, entt::entity entity) {
+    void on_construct(entt::registry &, entt::entity entity) {
         if (m_active && m_observed_entities.contains(entity)) {
             m_builder->emplace<Component>(entity);
         }
     }
 
     template<typename Component>
-    void on_update(entt::registry &registry, entt::entity entity) {
+    void on_update(entt::registry &, entt::entity entity) {
         if (m_active && m_observed_entities.contains(entity)) {
             m_builder->replace<Component>(entity);
         }
     }
 
     template<typename Component>
-    void on_destroy(entt::registry &registry, entt::entity entity) {
+    void on_destroy(entt::registry &, entt::entity entity) {
         if (m_active && m_observed_entities.contains(entity)) {
             m_builder->remove<Component>(entity);
         }

--- a/include/edyn/serialization/std_s11n.hpp
+++ b/include/edyn/serialization/std_s11n.hpp
@@ -19,7 +19,7 @@ namespace edyn {
 template<typename Archive>
 void serialize(Archive &archive, std::string& str) {
     using size_type = uint16_t;
-    size_type size = std::min(str.size(), static_cast<size_t>(std::numeric_limits<size_type>::max()));
+    size_type size = static_cast<size_type>(std::min(str.size(), static_cast<size_t>(std::numeric_limits<size_type>::max())));
     archive(size);
     str.resize(size);
 
@@ -31,7 +31,7 @@ void serialize(Archive &archive, std::string& str) {
 template<typename Archive, typename T>
 void serialize(Archive &archive, std::vector<T> &vector) {
     using size_type = uint16_t;
-    size_type size = std::min(vector.size(), static_cast<size_t>(std::numeric_limits<size_type>::max()));
+    size_type size = static_cast<size_type>(std::min(vector.size(), static_cast<size_t>(std::numeric_limits<size_type>::max())));
     archive(size);
     vector.resize(size);
 
@@ -43,7 +43,7 @@ void serialize(Archive &archive, std::vector<T> &vector) {
 template<typename Archive>
 void serialize(Archive &archive, std::vector<bool> &vector) {
     using size_type = uint16_t;
-    size_type size = std::min(vector.size(), static_cast<size_t>(std::numeric_limits<size_type>::max()));
+    size_type size = static_cast<size_type>(std::min(vector.size(), static_cast<size_t>(std::numeric_limits<size_type>::max())));
     archive(size);
     vector.resize(size);
 
@@ -188,7 +188,7 @@ size_t serialization_sizeof(const std::optional<T> &opt) {
 template<typename Archive, typename K, typename V>
 void serialize(Archive &archive, std::map<K, V> &map) {
     using size_type = uint16_t;
-    size_type size = std::min(map.size(), static_cast<size_t>(std::numeric_limits<size_type>::max()));
+    size_type size = static_cast<size_type>(std::min(map.size(), static_cast<size_t>(std::numeric_limits<size_type>::max())));
     archive(size);
 
     if constexpr(Archive::is_input::value) {

--- a/include/edyn/shapes/shapes.hpp
+++ b/include/edyn/shapes/shapes.hpp
@@ -124,7 +124,7 @@ void visit_shape(entt::registry &registry, entt::entity entity, VisitorType visi
  * direction.
  */
 template<typename ShapeType>
-constexpr vector3 shape_rolling_direction(const ShapeType &shape) {
+constexpr vector3 shape_rolling_direction(const ShapeType &) {
     return vector3_zero;
 }
 

--- a/include/edyn/util/collision_util.hpp
+++ b/include/edyn/util/collision_util.hpp
@@ -188,7 +188,7 @@ void process_collision(entt::registry &registry, entt::entity manifold_entity,
         contact_point_for_each(cp_view, manifold_state.contact_entity, [&](entt::entity contact_entity) {
             if (points_removed.contains(contact_entity)) return;
             auto [cp, cp_geom] = cp_view.template get<contact_point, contact_point_geometry>(contact_entity);
-            local_points[pt_idx].point = {cp.pivotA, cp.pivotB, cp.normal, cp_geom.distance};
+            local_points[pt_idx].point = {cp.pivotA, cp.pivotB, cp.normal, cp_geom.distance, {}, {}, {}};
             local_points[pt_idx].contact_entity = contact_entity;
             ++pt_idx;
         });

--- a/src/edyn/collision/broadphase.cpp
+++ b/src/edyn/collision/broadphase.cpp
@@ -215,7 +215,7 @@ void broadphase::collide_parallel() {
     m_pair_results.resize(aabb_proc_size);
 
     auto task = task_delegate_t(entt::connect_arg_t<&broadphase::collide_parallel_task>{}, *this);
-    enqueue_task_wait(*m_registry, task, aabb_proc_size);
+    enqueue_task_wait(*m_registry, task, static_cast<unsigned int>(aabb_proc_size));
 }
 
 void broadphase::finish_collide() {

--- a/src/edyn/collision/collide/collide_box_box.cpp
+++ b/src/edyn/collision/collide/collide_box_box.cpp
@@ -102,9 +102,9 @@ void collide(const box_shape &shA, const box_shape &shB,
         return;
     }
 
-    box_feature featureA, featureB;
-    size_t feature_indexA, feature_indexB;
-    scalar projectionA, projectionB;
+    box_feature featureA {}, featureB {};
+    size_t feature_indexA {0}, feature_indexB {0};
+    scalar projectionA {0}, projectionB {0};
 
     shA.support_feature(posA, ornA, vector3_zero, -sep_axis,
                         featureA, feature_indexA, projectionA,
@@ -116,8 +116,8 @@ void collide(const box_shape &shA, const box_shape &shB,
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureA = {featureA, feature_indexA};
-    point.featureB = {featureB, feature_indexB};
+    point.featureA = {featureA, feature_indexA, 0};
+    point.featureB = {featureB, feature_indexB, 0};
 
     if (featureA == box_feature::face && featureB == box_feature::face) {
         // Face-Face.

--- a/src/edyn/collision/collide/collide_box_mesh.cpp
+++ b/src/edyn/collision/collide/collide_box_mesh.cpp
@@ -131,8 +131,8 @@ static void collide_box_triangle(
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureA = {box_feature, box_feature_index};
-    point.featureB = {tri_feature};
+    point.featureA = {box_feature, box_feature_index, 0};
+    point.featureB = {tri_feature, 0, 0};
     point.featureB->index = get_triangle_mesh_feature_index(mesh, tri_idx, tri_feature, tri_feature_index);
 
     if (box_feature == box_feature::face && tri_feature == triangle_feature::face) {

--- a/src/edyn/collision/collide/collide_box_plane.cpp
+++ b/src/edyn/collision/collide/collide_box_plane.cpp
@@ -42,7 +42,7 @@ void collide(const box_shape &shA, const plane_shape &shB,
     collision_result::collision_point point;
     point.normal = shB.normal;
     point.distance = distance;
-    point.featureA = {featureA, feature_indexA};
+    point.featureA = {featureA, feature_indexA, 0};
     point.normal_attachment = contact_normal_attachment::normal_on_B;
 
     for (size_t i = 0; i < num_vertices; ++i) {

--- a/src/edyn/collision/collide/collide_capsule_box.cpp
+++ b/src/edyn/collision/collide/collide_capsule_box.cpp
@@ -52,7 +52,7 @@ void collide(const capsule_shape &shA, const box_shape &shB,
     // Box edges vs capsule edge.
     for (size_t i = 0; i < get_box_num_features(box_feature::edge); ++i) {
         auto [vertexA0, vertexA1] = shB.get_edge(i, posB, ornB);
-        scalar s, t;
+        scalar s {0}, t {0};
         vector3 closestA, closestB;
         closest_point_segment_segment(vertexA0, vertexA1,
                                       capsule_vertices[0], capsule_vertices[1],
@@ -100,9 +100,9 @@ void collide(const capsule_shape &shA, const box_shape &shB,
     }
 
     auto contact_origin_box = sep_axis * projection_box;
-    scalar feature_distanceB;
-    box_feature featureB;
-    size_t feature_indexB;
+    scalar feature_distanceB {0};
+    box_feature featureB {};
+    size_t feature_indexB {0};
     shB.support_feature(posB, ornB, contact_origin_box, sep_axis,
                         featureB, feature_indexB,
                         feature_distanceB, support_feature_tolerance);
@@ -110,8 +110,8 @@ void collide(const capsule_shape &shA, const box_shape &shB,
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureA = {featureA, feature_indexA};
-    point.featureB = {featureB, feature_indexB};
+    point.featureA = {featureA, feature_indexA, 0};
+    point.featureB = {featureB, feature_indexB, 0};
 
     switch (featureB) {
     case box_feature::face: {

--- a/src/edyn/collision/collide/collide_capsule_capsule.cpp
+++ b/src/edyn/collision/collide/collide_capsule_capsule.cpp
@@ -29,7 +29,7 @@ void collide(const capsule_shape &shA, const capsule_shape &shB,
     }
 
     vector3 normal;
-    scalar distance;
+    scalar distance {0};
 
     if (dist_sqr > EDYN_EPSILON) {
         auto dist = std::sqrt(dist_sqr);
@@ -58,16 +58,16 @@ void collide(const capsule_shape &shA, const capsule_shape &shB,
     point.normal_attachment = contact_normal_attachment::none;
 
     if (num_points == 2 || (s[0] > 0 && s[0] < 1)) {
-        point.featureA = {capsule_feature::side};
+        point.featureA = {capsule_feature::side, 0, 0};
     } else {
-        point.featureA = {capsule_feature::hemisphere};
+        point.featureA = {capsule_feature::hemisphere, 0, 0};
         point.featureA->index = s[0] == 0 ? 0 : 1;
     }
 
     if (num_points == 2 || (t[0] > 0 && t[0] < 1)) {
-        point.featureB = {capsule_feature::side};
+        point.featureB = {capsule_feature::side, 0, 0};
     } else {
-        point.featureB = {capsule_feature::hemisphere};
+        point.featureB = {capsule_feature::hemisphere, 0, 0};
         point.featureB->index = t[0] == 0 ? 0 : 1;
     }
 

--- a/src/edyn/collision/collide/collide_capsule_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_capsule_cylinder.cpp
@@ -163,8 +163,8 @@ void collide(const capsule_shape &shA, const cylinder_shape &shB,
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureA = {featureA, feature_indexA};
-    point.featureB = {featureB, feature_indexB};
+    point.featureA = {featureA, feature_indexA, 0};
+    point.featureB = {featureB, feature_indexB, 0};
 
     switch (featureB) {
     case cylinder_feature::face: {

--- a/src/edyn/collision/collide/collide_capsule_mesh.cpp
+++ b/src/edyn/collision/collide/collide_capsule_mesh.cpp
@@ -120,8 +120,8 @@ static void collide_capsule_triangle(
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureA = {featureA, feature_indexA};
-    point.featureB = {tri_feature};
+    point.featureA = {featureA, feature_indexA, 0};
+    point.featureB = {tri_feature, 0, 0};
     point.featureB->index = get_triangle_mesh_feature_index(mesh, tri_idx, tri_feature, tri_feature_index);
 
     switch (tri_feature) {

--- a/src/edyn/collision/collide/collide_capsule_plane.cpp
+++ b/src/edyn/collision/collide/collide_capsule_plane.cpp
@@ -33,7 +33,7 @@ void collide(const capsule_shape &shA, const plane_shape &shB,
         auto pivotA_world = vertex - shB.normal * shA.radius;
         auto pivotA = to_object_space(pivotA_world, ctx.posA, ctx.ornA);
         auto pivotB = project_plane(vertex, center, shB.normal);
-        result.add_point({pivotA, pivotB, shB.normal, distance, contact_normal_attachment::normal_on_B, featureA});
+        result.add_point({pivotA, pivotB, shB.normal, distance, contact_normal_attachment::normal_on_B, featureA, {}});
     }
 }
 

--- a/src/edyn/collision/collide/collide_capsule_sphere.cpp
+++ b/src/edyn/collision/collide/collide_capsule_sphere.cpp
@@ -10,7 +10,7 @@ namespace edyn {
 void collide(const capsule_shape &shA, const sphere_shape &shB,
              const collision_context &ctx, collision_result &result) {
     auto capsule_vertices = shA.get_vertices(ctx.posA, ctx.ornA);
-    vector3 closest; scalar t;
+    vector3 closest; scalar t {0};
     auto dist_sqr = closest_point_segment(capsule_vertices[0], capsule_vertices[1], ctx.posB, t, closest);
     auto min_dist = shA.radius + shB.radius + ctx.threshold;
 
@@ -20,7 +20,7 @@ void collide(const capsule_shape &shA, const sphere_shape &shB,
 
     auto normal = closest - ctx.posB;
     auto normal_len_sqr = length_sqr(normal);
-    scalar distance;
+    scalar distance {0};
 
     if (normal_len_sqr > EDYN_EPSILON) {
         auto normal_len = std::sqrt(normal_len_sqr);
@@ -42,9 +42,9 @@ void collide(const capsule_shape &shA, const sphere_shape &shB,
     point.normal_attachment = contact_normal_attachment::none;
 
     if (t > 0 && t < 1) {
-        point.featureA = {capsule_feature::side};
+        point.featureA = {capsule_feature::side, 0, 0};
     } else {
-        point.featureA = {capsule_feature::hemisphere};
+        point.featureA = {capsule_feature::hemisphere, 0, 0};
         point.featureA->index = t == 0 ? 0 : 1;
     }
 

--- a/src/edyn/collision/collide/collide_cylinder_box.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_box.cpp
@@ -177,8 +177,8 @@ void collide(const cylinder_shape &shA, const box_shape &shB,
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureA = {featureA, feature_indexA};
-    point.featureB = {featureB, feature_indexB};
+    point.featureA = {featureA, feature_indexA, 0};
+    point.featureB = {featureB, feature_indexB, 0};
 
     // Index of vector element in cylinder object space that represents the
     // cylinder axis followed by the indices of the elements of the axes

--- a/src/edyn/collision/collide/collide_cylinder_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_cylinder.cpp
@@ -182,8 +182,8 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureA = {featureA, feature_indexA};
-    point.featureB = {featureB, feature_indexB};
+    point.featureA = {featureA, feature_indexA, 0};
+    point.featureB = {featureB, feature_indexB, 0};
 
     auto get_local_distance = [&](vector3 pivotA, vector3 pivotB) {
         auto pivotA_world = to_world_space(pivotA, posA, ornA);

--- a/src/edyn/collision/collide/collide_cylinder_mesh.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_mesh.cpp
@@ -149,8 +149,8 @@ void collide_cylinder_triangle(
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureA = {cyl_feature, cyl_feature_index};
-    point.featureB = {tri_feature};
+    point.featureA = {cyl_feature, cyl_feature_index, 0};
+    point.featureB = {tri_feature, 0, 0};
     point.featureB->index = get_triangle_mesh_feature_index(mesh, tri_idx, tri_feature, tri_feature_index);
 
     // Index of vector element in cylinder object space that represents the

--- a/src/edyn/collision/collide/collide_cylinder_plane.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_plane.cpp
@@ -27,7 +27,7 @@ void collide(const cylinder_shape &shA, const plane_shape &shB,
     collision_result::collision_point point;
     point.normal = normal;
     point.distance = distance;
-    point.featureA = {featureA, feature_indexA};
+    point.featureA = {featureA, feature_indexA, 0};
     point.normal_attachment = contact_normal_attachment::normal_on_B;
 
     switch (featureA) {

--- a/src/edyn/collision/collide/collide_cylinder_sphere.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_sphere.cpp
@@ -44,7 +44,7 @@ void collide(const cylinder_shape &shA, const sphere_shape &shB,
         point.distance = dist - shA.radius - shB.radius;
         point.normal = normal;
         point.normal_attachment = contact_normal_attachment::none;
-        point.featureA = {cylinder_feature::side_edge};
+        point.featureA = {cylinder_feature::side_edge, 0, 0};
         result.add_point(point);
         return;
     }
@@ -76,10 +76,10 @@ void collide(const cylinder_shape &shA, const sphere_shape &shB,
 
     if (distance_sqr(sphere_proj, posA) < shA.radius * shA.radius) {
         point.normal_attachment = contact_normal_attachment::normal_on_A;
-        point.featureA = {cylinder_feature::face, cyl_face_idx};
+        point.featureA = {cylinder_feature::face, cyl_face_idx, 0};
     } else {
         point.normal_attachment = contact_normal_attachment::none;
-        point.featureA = {cylinder_feature::side_edge, cyl_face_idx};
+        point.featureA = {cylinder_feature::side_edge, cyl_face_idx, 0};
     }
 
     result.add_point(point);

--- a/src/edyn/collision/collide/collide_polyhedron_box.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_box.cpp
@@ -71,7 +71,7 @@ void collide(const polyhedron_shape &shA, const box_shape &shB,
 
     // Edge vs edge.
     scalar min_edge_dist = -EDYN_SCALAR_MAX;
-    scalar edge_projectionA, edge_projectionB;
+    scalar edge_projectionA {0}, edge_projectionB {0};
     auto edge_dir = vector3_zero;
 
     for (auto edge_idxA = 0u; edge_idxA < meshA.num_edges(); ++edge_idxA) {
@@ -142,7 +142,7 @@ void collide(const polyhedron_shape &shA, const box_shape &shB,
     // Separating axis is in A's space. Transform to global.
     point.normal = rotate(ctx.ornA, sep_axis);
     point.distance = distance;
-    point.featureB = {featureB, feature_indexB};
+    point.featureB = {featureB, feature_indexB, 0};
 
     switch (featureB) {
     case box_feature::face: {

--- a/src/edyn/collision/collide/collide_polyhedron_capsule.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_capsule.cpp
@@ -93,7 +93,7 @@ void collide(const polyhedron_shape &shA, const capsule_shape &shB,
             contact_normal_attachment::none;
 
     if (is_capsule_edge) {
-        point.featureB = {capsule_feature::side};
+        point.featureB = {capsule_feature::side, 0, 0};
 
         // Check if the vertices of the capsule are inside the polygon.
         if (polygon.hull.size() > 2) {
@@ -159,7 +159,7 @@ void collide(const polyhedron_shape &shA, const capsule_shape &shB,
         auto pivotB_world = closest_capsule_vertex + sep_axis * shB.radius;
         point.pivotB = to_object_space(pivotB_world, posB, ornB);
         point.pivotA = pivotB_world + sep_axis * distance;
-        point.featureB = {capsule_feature::hemisphere, closest_capsule_vertex_index};
+        point.featureB = {capsule_feature::hemisphere, closest_capsule_vertex_index, 0};
         result.add_point(point);
     }
 }

--- a/src/edyn/collision/collide/collide_polyhedron_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_cylinder.cpp
@@ -169,7 +169,7 @@ void collide(const polyhedron_shape &shA, const cylinder_shape &shB,
     collision_result::collision_point point;
     point.normal = normal;
     point.distance = distance;
-    point.featureB = {featureB, feature_indexB};
+    point.featureB = {featureB, feature_indexB, 0};
 
     auto cyl_ax_idx = static_cast<std::underlying_type_t<coordinate_axis>>(shB.axis);
     auto cyl_ax_idx_ortho0 = (cyl_ax_idx + 1) % 3;

--- a/src/edyn/collision/collide/collide_polyhedron_mesh.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_mesh.cpp
@@ -71,7 +71,7 @@ static void collide_polyhedron_triangle(
 
     // Edge vs edge.
     scalar min_edge_dist = -EDYN_SCALAR_MAX;
-    scalar edge_projection_poly, edge_projection_tri;
+    scalar edge_projection_poly {0}, edge_projection_tri {0};
     vector3 edge_dir;
 
     for (auto edge_idxA = 0u; edge_idxA < poly_mesh.num_edges(); ++edge_idxA) {
@@ -184,7 +184,7 @@ static void collide_polyhedron_triangle(
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureB = {tri_feature};
+    point.featureB = {tri_feature, 0, 0};
     point.featureB->index = get_triangle_mesh_feature_index(tri_mesh, tri_idx, tri_feature, tri_feature_index);
     point.normal_attachment = contact_normal_attachment::none;
 

--- a/src/edyn/collision/collide/collide_polyhedron_plane.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_plane.cpp
@@ -32,7 +32,7 @@ void collide(const polyhedron_shape &shA, const plane_shape &shB,
         auto pivotA = rotate(conjugate(ctx.ornA), pointA);
         auto local_distance = dot(pointA - center, normal);
         auto pivotB = pointA - normal * local_distance + posA; // Project onto plane.
-        result.maybe_add_point({pivotA, pivotB, normal, local_distance, normal_attachment});
+        result.maybe_add_point({pivotA, pivotB, normal, local_distance, normal_attachment, {}, {}});
     }
 }
 

--- a/src/edyn/collision/collide/collide_polyhedron_polyhedron.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_polyhedron.cpp
@@ -97,7 +97,7 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
 
     // Edge vs edge.
     scalar min_edge_dist = -EDYN_SCALAR_MAX;
-    scalar edge_projectionA, edge_projectionB;
+    scalar edge_projectionA {0}, edge_projectionB {0};
     vector3 edge_dir;
 
     for (auto edge_idxA = 0u; edge_idxA < meshA.num_edges(); ++edge_idxA) {
@@ -186,7 +186,7 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
                 auto pivotA = to_object_space(pointA, posA, ornA);
                 auto pivotB_world = project_plane(pointA, polygonB.origin, sep_axis);
                 auto pivotB = to_object_space(pivotB_world, posB, ornB);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment, {}, {}});
             }
         }
     }
@@ -199,7 +199,7 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
                 auto pivotB = to_object_space(pointB, posB, ornB);
                 auto pivotA_world = project_plane(pointB, polygonA.origin, sep_axis);
                 auto pivotA = to_object_space(pivotA_world, posA, ornA);
-                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
+                result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment, {}, {}});
             }
         }
     }
@@ -234,7 +234,7 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
                     auto pivotB_world = lerp(polygonB.vertices[idx0B], polygonB.vertices[idx1B], t[k]);
                     auto pivotA = to_object_space(pivotA_world, posA, ornA);
                     auto pivotB = to_object_space(pivotB_world, posB, ornB);
-                    result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment});
+                    result.maybe_add_point({pivotA, pivotB, sep_axis, distance, normal_attachment, {}, {}});
                 }
             }
         }

--- a/src/edyn/collision/collide/collide_polyhedron_sphere.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_sphere.cpp
@@ -56,7 +56,7 @@ void collide(const polyhedron_shape &shA, const sphere_shape &shB,
         auto normalB = rotate(conjugate(ornB), sep_axis);
         auto pivotB = normalB * shB.radius;
         auto normal = rotate(ctx.ornA, sep_axis);
-        result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::normal_on_A});
+        result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::normal_on_A, {}, {}});
         return;
     }
 
@@ -84,7 +84,7 @@ void collide(const polyhedron_shape &shA, const sphere_shape &shB,
     auto pivotB = normalB * shB.radius;
     auto normal = rotate(ctx.ornA, new_sep_axis);
 
-    result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::none});
+    result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::none, {}, {}});
 }
 
 void collide(const sphere_shape &shA, const polyhedron_shape &shB,

--- a/src/edyn/collision/collide/collide_sphere_box.cpp
+++ b/src/edyn/collision/collide/collide_sphere_box.cpp
@@ -21,7 +21,7 @@ void collide(const sphere_shape &shA, const box_shape &shB,
         return;
     }
 
-    scalar center_distance;
+    scalar center_distance {0};
     auto normal_attachment = contact_normal_attachment::none;
 
     // If `posA_in_B` lies inside the box, `closest_point_box_outside`
@@ -51,7 +51,7 @@ void collide(const sphere_shape &shA, const box_shape &shB,
     auto pivotB = closest;
     auto normal = rotate(ctx.ornB, normalB);
     auto distance = center_distance - shA.radius;
-    result.add_point({pivotA, pivotB, normal, distance, normal_attachment});
+    result.add_point({pivotA, pivotB, normal, distance, normal_attachment, {}, {}});
 }
 
 void collide(const box_shape &shA, const sphere_shape &shB,

--- a/src/edyn/collision/collide/collide_sphere_mesh.cpp
+++ b/src/edyn/collision/collide/collide_sphere_mesh.cpp
@@ -76,7 +76,7 @@ static void collide_sphere_triangle(
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
-    point.featureB = {tri_feature};
+    point.featureB = {tri_feature, 0, 0};
     point.featureB->index = get_triangle_mesh_feature_index(mesh, tri_idx, tri_feature, tri_feature_index);
 
     switch (tri_feature) {

--- a/src/edyn/collision/collide/collide_sphere_plane.cpp
+++ b/src/edyn/collision/collide/collide_sphere_plane.cpp
@@ -16,7 +16,7 @@ void collide(const sphere_shape &sphere, const plane_shape &plane,
     auto pivotA = rotate(conjugate(ctx.ornA), -normal * sphere.radius);
     auto pivotB = rotate(conjugate(ctx.ornB), d - normal * l - center);
     auto distance = l - sphere.radius;
-    result.add_point({pivotA, pivotB, plane.normal, distance, contact_normal_attachment::normal_on_B});
+    result.add_point({pivotA, pivotB, plane.normal, distance, contact_normal_attachment::normal_on_B, {}, {}});
 }
 
 void collide(const plane_shape &shA, const sphere_shape &shB,

--- a/src/edyn/collision/collide/collide_sphere_sphere.cpp
+++ b/src/edyn/collision/collide/collide_sphere_sphere.cpp
@@ -23,7 +23,7 @@ void collide(const sphere_shape &shA, const sphere_shape &shB,
     auto pivotB = rB;
     auto normal = dn;
     auto distance = dist - shA.radius - shB.radius;
-    result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::none});
+    result.add_point({pivotA, pivotB, normal, distance, contact_normal_attachment::none, {}, {}});
 }
 
 }

--- a/src/edyn/collision/dynamic_tree.cpp
+++ b/src/edyn/collision/dynamic_tree.cpp
@@ -349,7 +349,7 @@ void dynamic_tree::clear() {
     if (!m_nodes.empty()) {
         m_free_list = 0;
 
-        for (tree_node_id_t id = 0; id < m_nodes.size(); ++id) {
+        for (tree_node_id_t id = 0; id < static_cast<tree_node_id_t>(m_nodes.size()); ++id) {
             auto &node = m_nodes[id];
             node.entity = entt::null;
             node.height = -1;

--- a/src/edyn/collision/narrowphase.cpp
+++ b/src/edyn/collision/narrowphase.cpp
@@ -70,7 +70,7 @@ void narrowphase::detect_collision_parallel() {
     m_cp_destruction_infos.resize(num_manifolds);
 
     auto task = task_delegate_t(entt::connect_arg_t<&narrowphase::detect_collision_parallel_range>{}, *this);
-    enqueue_task_wait(*m_registry, task, num_manifolds);
+    enqueue_task_wait(*m_registry, task, static_cast<unsigned int>(num_manifolds));
 }
 
 void narrowphase::finish_detect_collision() {

--- a/src/edyn/collision/raycast.cpp
+++ b/src/edyn/collision/raycast.cpp
@@ -157,7 +157,7 @@ shape_raycast_result shape_raycast(const cylinder_shape &cylinder, const raycast
         auto result = shape_raycast_result{};
         result.fraction = fraction_in;
         result.normal = intersect_result.normal / std::sqrt(intersect_result.dist_sqr);
-        result.info_var = cylinder_raycast_info{cylinder_feature::side_edge};
+        result.info_var = cylinder_raycast_info{cylinder_feature::side_edge, 0};
         return result;
     }
 
@@ -245,7 +245,7 @@ shape_raycast_result shape_raycast(const capsule_shape &capsule, const raycast_c
         auto result = shape_raycast_result{};
         result.fraction = u_in;
         result.normal = intersect_result.normal / std::sqrt(intersect_result.dist_sqr);
-        result.info_var = capsule_raycast_info{capsule_feature::side};
+        result.info_var = capsule_raycast_info{capsule_feature::side, 0};
 
         return result;
     }
@@ -337,7 +337,7 @@ shape_raycast_result shape_raycast(const compound_shape &compound, const raycast
         if (child_result.fraction < result.fraction) {
             result.fraction = child_result.fraction;
             result.normal = rotate(ctx.orn, child_result.normal);
-            auto info = compound_raycast_info{node_index};
+            auto info = compound_raycast_info{node_index, {}};
             // Obtain and assign relevant child info.
             using child_info_var_t = decltype(info.child_info_var);
             std::visit([&](auto &&child_info) {

--- a/src/edyn/collision/raycast_service.cpp
+++ b/src/edyn/collision/raycast_service.cpp
@@ -29,7 +29,7 @@ void raycast_service::run_broadphase(bool mt) {
         };
 
         auto task = task_delegate_t(entt::connect_arg_t<&decltype(task_func)::operator()>{}, task_func);
-        enqueue_task_wait(*m_registry, task, m_broad_ctx.size());
+        enqueue_task_wait(*m_registry, task, static_cast<unsigned int>(m_broad_ctx.size()));
     } else {
         for (auto &ctx : m_broad_ctx) {
             bphase.raycast(ctx.p0, ctx.p1, [&](entt::entity entity) {
@@ -81,7 +81,7 @@ void raycast_service::run_narrowphase(bool mt) {
         };
 
         auto task = task_delegate_t(entt::connect_arg_t<&decltype(task_func)::operator()>{}, task_func);
-        enqueue_task_wait(*m_registry, task, m_narrow_ctx.size());
+        enqueue_task_wait(*m_registry, task, static_cast<unsigned int>(m_narrow_ctx.size()));
     } else {
         auto index_view = m_registry->view<shape_index>();
         auto tr_view = m_registry->view<position, orientation>();

--- a/src/edyn/constraints/contact_extras_constraint.cpp
+++ b/src/edyn/constraints/contact_extras_constraint.cpp
@@ -24,8 +24,8 @@ void contact_extras_constraint::prepare(constraint_row_prep_cache &cache, scalar
         auto normal_relvel = dot(relvel, normal);
         // Divide stiffness by number of points for correct force
         // distribution. All points have the same stiffness.
-        auto spring_force = -distance * stiffness / num_points;
-        auto damper_force = -normal_relvel * damping / num_points;
+        auto spring_force = -distance * stiffness / static_cast<scalar>(num_points);
+        auto damper_force = -normal_relvel * damping / static_cast<scalar>(num_points);
 
         auto &normal_row = cache.get_current_row();
         normal_row.upper_limit = std::max(spring_force + damper_force, scalar(0)) * dt;

--- a/src/edyn/constraints/generic_constraint.cpp
+++ b/src/edyn/constraints/generic_constraint.cpp
@@ -57,7 +57,7 @@ void generic_constraint::prepare(
                 }
 
                 options.restitution = dof.limit_restitution;
-                options.erp = 0.9;
+                options.erp = scalar(0.9);
             } else {
                 row.lower_limit = -large_scalar;
                 row.upper_limit = large_scalar;

--- a/src/edyn/dynamics/moment_of_inertia.cpp
+++ b/src/edyn/dynamics/moment_of_inertia.cpp
@@ -156,7 +156,7 @@ matrix3x3 moment_of_inertia_polyhedron(scalar mass,
     };
 }
 
-matrix3x3 moment_of_inertia(const plane_shape &sh, scalar mass) {
+matrix3x3 moment_of_inertia(const plane_shape &/*sh*/, scalar /*mass*/) {
     return diagonal_matrix(vector3_max);
 }
 
@@ -172,7 +172,7 @@ matrix3x3 moment_of_inertia(const capsule_shape &sh, scalar mass) {
     return diagonal_matrix(moment_of_inertia_solid_capsule(mass, sh.half_length * 2, sh.radius, sh.axis));
 }
 
-matrix3x3 moment_of_inertia(const mesh_shape &sh, scalar mass) {
+matrix3x3 moment_of_inertia(const mesh_shape &/*sh*/, scalar /*mass*/) {
     return diagonal_matrix(vector3_max);
 }
 
@@ -202,7 +202,7 @@ matrix3x3 moment_of_inertia(const compound_shape &sh, scalar mass) {
     return inertia;
 }
 
-matrix3x3 moment_of_inertia(const paged_mesh_shape &sh, scalar mass) {
+matrix3x3 moment_of_inertia(const paged_mesh_shape &/*sh*/, scalar /*mass*/) {
     return diagonal_matrix(vector3_max);
 }
 

--- a/src/edyn/dynamics/restitution_solver.cpp
+++ b/src/edyn/dynamics/restitution_solver.cpp
@@ -84,7 +84,7 @@ static thread_local delta_linvel dummy_dv {vector3_zero};
 static thread_local delta_angvel dummy_dw {vector3_zero};
 
 bool solve_restitution_iteration(entt::registry &registry, entt::entity island_entity,
-                                 scalar dt, unsigned individual_iterations) {
+                                 scalar /*dt*/, unsigned individual_iterations) {
     auto body_view = registry.view<position, orientation, linvel, angvel,
                                    mass_inv, inertia_world_inv,
                                    delta_linvel, delta_angvel>();
@@ -166,13 +166,13 @@ bool solve_restitution_iteration(entt::registry &registry, entt::entity island_e
             // Use zero mass, inertia and velocities otherwise.
             vector3 linvelA, linvelB;
             vector3 angvelA, angvelB;
-            scalar inv_mA, inv_mB;
-            matrix3x3 inv_IA, inv_IB;
-            delta_linvel *dvA, *dvB;
-            delta_angvel *dwA, *dwB;
+            scalar inv_mA {0}, inv_mB {0};
+            matrix3x3 inv_IA {}, inv_IB {};
+            delta_linvel *dvA {nullptr}, *dvB {nullptr};
+            delta_angvel *dwA {nullptr}, *dwB {nullptr};
 
             if (procedural_view.contains(manifold.body[0])) {
-                inv_mA = body_view.get<mass_inv>(manifold.body[0]);
+                inv_mA = body_view.get<mass_inv>(manifold.body[0]).s;
                 inv_IA = body_view.get<inertia_world_inv>(manifold.body[0]);
             } else {
                 inv_mA = 0;
@@ -196,7 +196,7 @@ bool solve_restitution_iteration(entt::registry &registry, entt::entity island_e
             }
 
             if (procedural_view.contains(manifold.body[1])) {
-                inv_mB = body_view.get<mass_inv>(manifold.body[1]);
+                inv_mB = body_view.get<mass_inv>(manifold.body[1]).s;
                 inv_IB = body_view.get<inertia_world_inv>(manifold.body[1]);
             } else {
                 inv_mB = 0;
@@ -229,7 +229,7 @@ bool solve_restitution_iteration(entt::registry &registry, entt::entity island_e
                 auto rA = pivotA - posA;
                 auto rB = pivotB - posB;
 
-                auto normal_row_index = normal_rows.size();
+                auto normal_row_index = static_cast<unsigned>(normal_rows.size());
                 auto &normal_row = normal_rows.emplace_back();
                 normal_row.J = {normal, cross(rA, normal), -normal, -cross(rB, normal)};
                 normal_row.inv_mA = inv_mA; normal_row.inv_IA = inv_IA;

--- a/src/edyn/math/geom.cpp
+++ b/src/edyn/math/geom.cpp
@@ -1246,7 +1246,7 @@ intersect_ray_cylinder_result intersect_ray_cylinder(vector3 p0, vector3 p1,
     scalar s, t;
 
     if (!closest_point_line_line(cyl_vertices[0], cyl_vertices[1], p0, p1, s, t)) {
-        return {intersect_ray_cylinder_result::kind::parallel_directions};
+        return {intersect_ray_cylinder_result::kind::parallel_directions, {}, {}};
     }
 
     auto radius_sqr = square(radius);
@@ -1257,7 +1257,7 @@ intersect_ray_cylinder_result intersect_ray_cylinder(vector3 p0, vector3 p1,
 
     // Distance between lines bigger than radius.
     if (dist_sqr > radius_sqr) {
-        return {intersect_ray_cylinder_result::kind::distance_greater_than_radius};
+        return {intersect_ray_cylinder_result::kind::distance_greater_than_radius, {}, {}};
     }
 
     // Offset `t` backwards to place it where the intersection happens.

--- a/src/edyn/networking/sys/client_side.cpp
+++ b/src/edyn/networking/sys/client_side.cpp
@@ -494,7 +494,7 @@ static void process_packet(entt::registry &registry, const packet::create_entity
             EDYN_ASSERT(
                 (registry.all_of<dynamic_tag>(entity) && *mass > 0 && *mass < EDYN_SCALAR_MAX) ||
                 (registry.any_of<kinematic_tag, static_tag>(entity) && *mass == EDYN_SCALAR_MAX));
-            auto inv = registry.all_of<dynamic_tag>(entity) ? scalar(1) / *mass : scalar(0);
+            auto inv = registry.all_of<dynamic_tag>(entity) ? scalar(1) / mass->s : scalar(0);
             registry.emplace<mass_inv>(entity, inv);
         }
 

--- a/src/edyn/networking/sys/server_side.cpp
+++ b/src/edyn/networking/sys/server_side.cpp
@@ -43,7 +43,7 @@
 
 namespace edyn {
 
-static void process_packet(entt::registry &registry, entt::entity client_entity, packet::registry_snapshot &snapshot) {
+static void process_packet(entt::registry &registry, entt::entity /*client_entity*/, packet::registry_snapshot &snapshot) {
     if (auto *stepper = registry.ctx().find<stepper_async>()) {
         stepper->send_message_to_worker<msg::apply_network_pools>(std::move(snapshot.entities), std::move(snapshot.pools), false);
     } else {
@@ -130,7 +130,7 @@ static void process_packet(entt::registry &registry, entt::entity client_entity,
             EDYN_ASSERT(
                 (registry.all_of<dynamic_tag>(local_entity) && *mass > 0 && *mass < EDYN_SCALAR_MAX) ||
                 (registry.any_of<kinematic_tag, static_tag>(local_entity) && *mass == EDYN_SCALAR_MAX));
-            auto inv = registry.all_of<dynamic_tag>(local_entity) ? scalar(1) / *mass : scalar(0);
+            auto inv = registry.all_of<dynamic_tag>(local_entity) ? scalar(1) / mass->s : scalar(0);
             registry.emplace<mass_inv>(local_entity, inv);
         }
 

--- a/src/edyn/serialization/paged_triangle_mesh_s11n.cpp
+++ b/src/edyn/serialization/paged_triangle_mesh_s11n.cpp
@@ -125,7 +125,7 @@ void paged_triangle_mesh_file_input_archive::load(paged_triangle_mesh *trimesh, 
     }
 }
 
-void load_mesh_context::load(unsigned start, unsigned end) {
+void load_mesh_context::load(unsigned /*start*/, unsigned /*end*/) {
     auto *input = reinterpret_cast<paged_triangle_mesh_file_input_archive *>(m_input);
     auto mesh = std::make_shared<triangle_mesh>();
 

--- a/src/edyn/shapes/box_shape.cpp
+++ b/src/edyn/shapes/box_shape.cpp
@@ -104,7 +104,7 @@ void box_shape::support_feature(const vector3 &pos, const quaternion &orn,
     projection += dot(pos - axis_pos, axis_dir);
 }
 
-void box_shape::support_feature(const vector3 &pos, const quaternion &orn,
+void box_shape::support_feature(const vector3 &/*pos*/, const quaternion &orn,
                                 const vector3 &axis_dir, box_feature &feature,
                                 size_t &feature_index, scalar threshold) const {
     auto local_dir = rotate(conjugate(orn), axis_dir);

--- a/src/edyn/shapes/compound_shape.cpp
+++ b/src/edyn/shapes/compound_shape.cpp
@@ -19,7 +19,7 @@ void compound_shape::finish() {
         aabbs.push_back(node.aabb);
     }
 
-    auto report_leaf = [](static_tree::tree_node &node, auto ids_begin, auto ids_end) {
+    auto report_leaf = [](static_tree::tree_node &node, auto ids_begin, auto /*ids_end*/) {
         node.id = *ids_begin;
     };
     tree.build(aabbs.begin(), aabbs.end(), report_leaf);

--- a/src/edyn/shapes/convex_mesh.cpp
+++ b/src/edyn/shapes/convex_mesh.cpp
@@ -149,7 +149,7 @@ void convex_mesh::calculate_edges() {
                     // edge will be directed along the circumference of the first face
                     // as well.
                     EDYN_ASSERT(edge_faces[edge_idx * 2 + 1] == std::numeric_limits<uint32_t>::max());
-                    edge_faces[edge_idx * 2 + 1] = face_idx;
+                    edge_faces[edge_idx * 2 + 1] = static_cast<uint32_t>(face_idx);
                     edge_normals[edge_idx * 2 + 1] = normals[face_idx];
                     break;
                 }
@@ -158,7 +158,7 @@ void convex_mesh::calculate_edges() {
             if (!contains) {
                 edges.push_back(vertex_idx0);
                 edges.push_back(vertex_idx1);
-                edge_faces.push_back(face_idx);
+                edge_faces.push_back(static_cast<uint32_t>(face_idx));
                 edge_faces.push_back(std::numeric_limits<uint32_t>::max());
 
                 edge_vertices.push_back(vertices[vertex_idx0]);
@@ -202,7 +202,7 @@ void convex_mesh::calculate_relevant_faces() {
         });
 
         if (found_it == relevant_faces.end()) {
-            relevant_faces.push_back(face_idx);
+            relevant_faces.push_back(static_cast<uint32_t>(face_idx));
             relevant_normals.push_back(normals[face_idx]);
         }
     }
@@ -221,7 +221,7 @@ void convex_mesh::calculate_relevant_edges() {
         });
 
         if (found_it == relevant_edges.end()) {
-            relevant_edges.push_back(edge_idx);
+            relevant_edges.push_back(static_cast<uint32_t>(edge_idx));
         }
     }
 }

--- a/src/edyn/shapes/cylinder_shape.cpp
+++ b/src/edyn/shapes/cylinder_shape.cpp
@@ -49,7 +49,7 @@ void cylinder_shape::support_feature(const vector3 &dir, cylinder_feature &out_f
     out_feature_index = dir[cyl_ax_idx] > 0 ? 0 : 1;
 }
 
-void cylinder_shape::support_feature(const vector3 &pos, const quaternion &orn, const vector3 &axis_dir,
+void cylinder_shape::support_feature(const vector3 &/*pos*/, const quaternion &orn, const vector3 &axis_dir,
                                      cylinder_feature &out_feature, size_t &out_feature_index,
                                      scalar threshold) const {
     auto local_dir = rotate(conjugate(orn), axis_dir);

--- a/src/edyn/shapes/paged_triangle_mesh.cpp
+++ b/src/edyn/shapes/paged_triangle_mesh.cpp
@@ -135,7 +135,7 @@ bool paged_triangle_mesh::has_per_vertex_material_id() const {
     return false;
 }
 
-AABB make_point_aabb(vector3 point, scalar size = 0.005) {
+AABB make_point_aabb(vector3 point, scalar size = scalar(0.005)) {
     auto extents = vector3_one * size;
     return {point - extents, point + extents};
 }

--- a/src/edyn/shapes/polyhedron_shape.cpp
+++ b/src/edyn/shapes/polyhedron_shape.cpp
@@ -5,7 +5,7 @@
 namespace edyn {
 
 polyhedron_shape::polyhedron_shape(std::shared_ptr<convex_mesh> mesh)
-    : mesh(mesh)
+    : mesh(std::move(mesh))
 {}
 
 }

--- a/src/edyn/shapes/triangle_mesh.cpp
+++ b/src/edyn/shapes/triangle_mesh.cpp
@@ -53,17 +53,17 @@ void triangle_mesh::init_edge_indices() {
                 m_edge_face_indices.push_back({idx_max, idx_max});
             }
 
-            vertex_edge_indices[i0].insert(edge_idx);
-            vertex_edge_indices[i1].insert(edge_idx);
+            vertex_edge_indices[i0].insert(static_cast<unsigned int>(edge_idx));
+            vertex_edge_indices[i1].insert(static_cast<unsigned int>(edge_idx));
 
-            m_face_edge_indices[face_idx][i] = edge_idx;
+            m_face_edge_indices[face_idx][i] = static_cast<unsigned int>(edge_idx);
 
             auto &edge_face_indices = m_edge_face_indices[edge_idx];
 
             if (edge_face_indices[0] == idx_max) {
-                edge_face_indices[0] = face_idx;
+                edge_face_indices[0] = static_cast<unsigned int>(face_idx);
             } else if (face_idx != edge_face_indices[0]){
-                edge_face_indices[1] = face_idx;
+                edge_face_indices[1] = static_cast<unsigned int>(face_idx);
             }
         }
     }
@@ -79,7 +79,7 @@ void triangle_mesh::init_edge_indices() {
     m_is_boundary_edge.resize(m_edge_vertex_indices.size());
 
     // Edges with a single valid _edge face index_ are at the boundary.
-    for (index_type edge_idx = 0; edge_idx < m_edge_face_indices.size(); ++edge_idx) {
+    for (index_type edge_idx = 0; edge_idx < static_cast<index_type>(m_edge_face_indices.size()); ++edge_idx) {
         auto &edge_face_indices = m_edge_face_indices[edge_idx];
         EDYN_ASSERT(edge_face_indices[0] != idx_max);
 
@@ -112,7 +112,7 @@ void triangle_mesh::calculate_adjacent_normals() {
             if (other_face_idx == face_idx) {
                 // This is a boundary edge. Make adjacent normal point slightly
                 // away in the edge direction to form a near 180 degree angle.
-                m_adjacent_normals[face_idx][i] = -normalize(m_normals[face_idx] + edge_normal * 0.1);
+                m_adjacent_normals[face_idx][i] = -normalize(m_normals[face_idx] + edge_normal * scalar(0.1));
                 // Boundary edges are always convex.
                 m_is_convex_edge[edge_idx] = true;
             } else {
@@ -137,7 +137,7 @@ void triangle_mesh::build_triangle_tree() {
         aabbs.push_back(tri_aabb);
     }
 
-    auto report_leaf = [](static_tree::tree_node &node, auto ids_begin, auto ids_end) {
+    auto report_leaf = [](static_tree::tree_node &node, auto ids_begin, auto /*ids_end*/) {
         node.id = *ids_begin;
     };
     m_triangle_tree.build(aabbs.begin(), aabbs.end(), report_leaf);

--- a/src/edyn/simulation/island_manager.cpp
+++ b/src/edyn/simulation/island_manager.cpp
@@ -36,11 +36,11 @@ island_manager::~island_manager() {
     m_registry->destroy(island_view.begin(), island_view.end());
 }
 
-void island_manager::on_construct_graph_node(entt::registry &registry, entt::entity entity) {
+void island_manager::on_construct_graph_node(entt::registry &/*registry*/, entt::entity entity) {
     m_new_graph_nodes.push_back(entity);
 }
 
-void island_manager::on_construct_graph_edge(entt::registry &registry, entt::entity entity) {
+void island_manager::on_construct_graph_edge(entt::registry &/*registry*/, entt::entity entity) {
     m_new_graph_edges.push_back(entity);
 }
 
@@ -425,10 +425,10 @@ void island_manager::split_islands() {
 
         // Find biggest island among all and move that into the original as to
         // minimize the amount of changes.
-        unsigned biggest_size = 0;
-        unsigned biggest_idx = 0;
+        size_t biggest_size = 0;
+        size_t biggest_idx = 0;
 
-        for (unsigned i = 0; i < islands.size(); ++i) {
+        for (size_t i = 0; i < islands.size(); ++i) {
             auto &island = islands[i];
 
             if (island.nodes.size() > biggest_size) {

--- a/src/edyn/simulation/simulation_worker.cpp
+++ b/src/edyn/simulation/simulation_worker.cpp
@@ -155,11 +155,11 @@ void simulation_worker::deinit() {
     }
 }
 
-void simulation_worker::on_construct_shared_entity(entt::registry &registry, entt::entity entity) {
+void simulation_worker::on_construct_shared_entity(entt::registry &/*registry*/, entt::entity entity) {
     m_op_observer->observe(entity);
 }
 
-void simulation_worker::on_destroy_shared_entity(entt::registry &registry, entt::entity entity) {
+void simulation_worker::on_destroy_shared_entity(entt::registry &/*registry*/, entt::entity entity) {
     m_op_observer->unobserve(entity);
 
     if (m_entity_map.contains_local(entity)) {
@@ -393,7 +393,7 @@ void simulation_worker::update() {
         // Scale up the effective delta time of each step. Physics will be
         // updated using fixed dt always but the presentation step dt will be
         // greater thus slowing down the simulation.
-        step_dt = advance_dt / effective_steps;
+        step_dt = static_cast<scalar>(advance_dt / static_cast<double>(effective_steps));
     }
 
     m_poly_initializer.init_new_shapes();
@@ -486,7 +486,7 @@ void simulation_worker::run() {
         auto error = desired_dt - dt;
         i_term = std::max(-1.0, std::min(i_term + integral_term * error, 1.0));
         auto delay = std::max(0.0, proportional_term * error + i_term);
-        edyn::delay(delay * 1000);
+        edyn::delay(static_cast<uint32_t>(delay * 1000));
     }
 
     deinit();

--- a/src/edyn/simulation/stepper_async.cpp
+++ b/src/edyn/simulation/stepper_async.cpp
@@ -64,7 +64,7 @@ stepper_async::~stepper_async() {
     m_message_queue_handle.update(); // Flush remaining messages.
 }
 
-void stepper_async::on_construct_shared(entt::registry &registry, entt::entity entity) {
+void stepper_async::on_construct_shared(entt::registry &/*registry*/, entt::entity entity) {
     m_op_observer->observe(entity);
 }
 
@@ -224,7 +224,7 @@ void stepper_async::on_query_aabb_response(message<msg::query_aabb_response> &ms
     m_query_aabb_ctx.erase(response.id);
 }
 
-void stepper_async::on_profiling(message<msg::profiling> &msg) {
+void stepper_async::on_profiling([[maybe_unused]] message<msg::profiling> &msg) {
 #ifndef EDYN_DISABLE_PROFILING
     m_registry->ctx().get<profile_timers>() = msg.content.timers;
     m_registry->ctx().get<profile_counters>() = msg.content.counters;
@@ -246,7 +246,7 @@ void stepper_async::calculate_presentation_delay(double current_time, double ela
     auto time_diff = std::min(current_time - m_sim_time, 1.0);
     m_time_diff_samples.back() = time_diff;
 
-    auto time_diff_avg = std::accumulate(m_time_diff_samples.begin(), m_time_diff_samples.end(), 0.0) / m_time_diff_samples.size();
+    auto time_diff_avg = std::accumulate(m_time_diff_samples.begin(), m_time_diff_samples.end(), 0.0) / static_cast<double>(m_time_diff_samples.size());
     auto time_diff_dev = m_time_diff_samples; // Calculate deviation from average.
 
     for (auto &val : time_diff_dev) {

--- a/src/edyn/simulation/stepper_sequential.cpp
+++ b/src/edyn/simulation/stepper_sequential.cpp
@@ -61,7 +61,7 @@ void stepper_sequential::update(double time) {
     if (effective_steps > settings.max_steps_per_update) {
         effective_steps = settings.max_steps_per_update;
         // Scale up the effective delta time in each step.
-        step_dt = advance_dt / effective_steps;
+        step_dt = static_cast<scalar>(advance_dt / static_cast<double>(effective_steps));
     }
 
     // Initialize new AABBs and shapes even in case num_steps is zero.
@@ -71,7 +71,7 @@ void stepper_sequential::update(double time) {
     for (unsigned i = 0; i < effective_steps; ++i) {
         EDYN_PROFILE_BEGIN(step_prof_time);
 
-        auto step_time = sim_time + step_dt * i;
+        auto step_time = sim_time + step_dt * static_cast<scalar>(i);
 
         if (settings.pre_step_callback) {
             (*settings.pre_step_callback)(*m_registry);

--- a/src/edyn/sys/update_aabbs.cpp
+++ b/src/edyn/sys/update_aabbs.cpp
@@ -20,7 +20,7 @@ AABB updated_aabb(const ShapeType &shape, const vector3 &pos, const quaternion &
 
 template<>
 AABB updated_aabb(const polyhedron_shape &polyhedron,
-                  const vector3 &pos, const quaternion &orn) {
+                  const vector3 &pos, const quaternion &/*orn*/) {
     // `shape_aabb(const polyhedron_shape &, ...)` rotates each vertex of a
     // polyhedron to calculate the AABB. Specialize `updated_aabb` for
     // polyhedrons to use the rotated mesh.

--- a/src/edyn/sys/update_presentation.cpp
+++ b/src/edyn/sys/update_presentation.cpp
@@ -34,13 +34,13 @@ static void update_discontinuities(entt::registry &registry, double dt) {
     const auto rate = network_settings.discontinuity_decay_rate;
     dis_view.each([rate, dt](discontinuity &dis) {
         if (length_sqr(dis.position_offset) > scalar(0.0001)) {
-            dis.position_offset -= dis.position_offset * std::min(rate * dt, 1.0);
+            dis.position_offset -= dis.position_offset * static_cast<scalar>(std::min(rate * dt, 1.0));
         } else {
             dis.position_offset = edyn::vector3_zero;
         }
 
         if (std::abs(dis.orientation_offset.w) < scalar(0.9999)) {
-            dis.orientation_offset = slerp(dis.orientation_offset, quaternion_identity, std::min(rate * dt, 1.0));
+            dis.orientation_offset = slerp(dis.orientation_offset, quaternion_identity, static_cast<scalar>(std::min(rate * dt, 1.0)));
         } else {
             dis.orientation_offset = quaternion_identity;
         }

--- a/src/edyn/time/unix/time.cpp
+++ b/src/edyn/time/unix/time.cpp
@@ -91,8 +91,8 @@ uint32_t ticks()
 #elif HAVE_CLOCK_GETTIME
         struct timespec now;
         clock_gettime(EDYN_MONOTONIC_CLOCK, &now);
-        ticks = (now.tv_sec - info.start_ts.tv_sec) * 1e3 + (now.tv_nsec -
-                                                 info.start_ts.tv_nsec) / 1e6;
+        ticks = static_cast<uint32_t>((now.tv_sec - info.start_ts.tv_sec) * 1000 + (now.tv_nsec -
+                                                 info.start_ts.tv_nsec) / 1000000);
 #else
         EDYN_ASSERT(false);
         ticks = 0;
@@ -101,7 +101,7 @@ uint32_t ticks()
         struct timeval now;
 
         gettimeofday(&now, nullptr);
-        ticks = (uint32_t)((now.tv_sec - info.start_tv.tv_sec) * 1e3 + (now.tv_usec - info.start_tv.tv_usec) / 1e3);
+        ticks = static_cast<uint32_t>((now.tv_sec - info.start_tv.tv_sec) * 1000 + (now.tv_usec - info.start_tv.tv_usec) / 1000);
     }
     return (ticks);
 }
@@ -115,7 +115,7 @@ uint64_t performance_counter() {
 
         clock_gettime(EDYN_MONOTONIC_CLOCK, &now);
         ticks = now.tv_sec;
-        ticks *= 1e9;
+        ticks *= 1000000000;
         ticks += now.tv_nsec;
 #elif defined(__APPLE__)
         ticks = mach_absolute_time();
@@ -128,7 +128,7 @@ uint64_t performance_counter() {
 
         gettimeofday(&now, nullptr);
         ticks = now.tv_sec;
-        ticks *= 1e6;
+        ticks *= 1000000;
         ticks += now.tv_usec;
     }
     return (ticks);
@@ -162,8 +162,8 @@ void delay(uint32_t ms) {
 
     /* Set the timeout interval */
 #if HAVE_NANOSLEEP
-    elapsed.tv_sec = ms / 1e3;
-    elapsed.tv_nsec = (ms % 1000) * 1e6;
+    elapsed.tv_sec = ms / 1000;
+    elapsed.tv_nsec = (ms % 1000) * 1000000;
 #else
     then = ticks();
 #endif

--- a/src/edyn/util/aabb_util.cpp
+++ b/src/edyn/util/aabb_util.cpp
@@ -164,12 +164,12 @@ AABB point_cloud_aabb(const std::vector<vector3> &points,
     return aabb;
 }
 
-AABB shape_aabb(const plane_shape &sh, const vector3 &pos, const quaternion &orn) {
+AABB shape_aabb(const plane_shape &sh, const vector3 &/*pos*/, const quaternion &/*orn*/) {
     // Position and orientation are ignored for planes.
     return plane_aabb(sh.normal, sh.constant);
 }
 
-AABB shape_aabb(const sphere_shape &sh, const vector3 &pos, const quaternion &orn) {
+AABB shape_aabb(const sphere_shape &sh, const vector3 &pos, const quaternion &/*orn*/) {
     return sphere_aabb(sh.radius, pos);
 }
 
@@ -181,7 +181,7 @@ AABB shape_aabb(const capsule_shape &sh, const vector3 &pos, const quaternion &o
     return capsule_aabb(sh.radius, sh.half_length, sh.axis, pos, orn);
 }
 
-AABB shape_aabb(const mesh_shape &sh, const vector3 &pos, const quaternion &orn) {
+AABB shape_aabb(const mesh_shape &sh, const vector3 &pos, const quaternion &/*orn*/) {
     return {
         sh.trimesh->get_aabb().min + pos,
         sh.trimesh->get_aabb().max + pos
@@ -196,7 +196,7 @@ AABB shape_aabb(const polyhedron_shape &sh, const vector3 &pos, const quaternion
     return point_cloud_aabb(sh.mesh->vertices, pos, orn);
 }
 
-AABB shape_aabb(const paged_mesh_shape &sh, const vector3 &pos, const quaternion &orn) {
+AABB shape_aabb(const paged_mesh_shape &sh, const vector3 &pos, const quaternion &/*orn*/) {
     return {
         sh.trimesh->get_aabb().min + pos,
         sh.trimesh->get_aabb().max + pos

--- a/src/edyn/util/polyhedron_shape_initializer.cpp
+++ b/src/edyn/util/polyhedron_shape_initializer.cpp
@@ -40,11 +40,11 @@ polyhedron_shape_initializer::~polyhedron_shape_initializer() {
     }
 }
 
-void polyhedron_shape_initializer::on_construct_polyhedron_shape(entt::registry &registry, entt::entity entity) {
+void polyhedron_shape_initializer::on_construct_polyhedron_shape(entt::registry &/*registry*/, entt::entity entity) {
     m_new_polyhedron_shapes.push_back(entity);
 }
 
-void polyhedron_shape_initializer::on_construct_compound_shape(entt::registry &registry, entt::entity entity) {
+void polyhedron_shape_initializer::on_construct_compound_shape(entt::registry &/*registry*/, entt::entity entity) {
     m_new_compound_shapes.push_back(entity);
 }
 

--- a/src/edyn/util/ragdoll.cpp
+++ b/src/edyn/util/ragdoll.cpp
@@ -31,31 +31,31 @@ ragdoll_def make_ragdoll_def_from_simple(const ragdoll_simple_def &simple_def) {
     rag_def.leg_upper_mass = simple_def.weight * 8 / 72;
     rag_def.leg_lower_mass = simple_def.weight * 7 / 72;
     rag_def.foot_mass = simple_def.weight * 1 / 72;
-    rag_def.shoulder_mass = simple_def.weight * 1.5 / 72;
-    rag_def.arm_upper_mass = simple_def.weight * 2.5 / 72;
+    rag_def.shoulder_mass = simple_def.weight * 1.5f / 72;
+    rag_def.arm_upper_mass = simple_def.weight * 2.5f / 72;
     rag_def.arm_lower_mass = simple_def.weight * 2 / 72;
-    rag_def.hand_mass = simple_def.weight * 0.5 / 72;
+    rag_def.hand_mass = simple_def.weight * 0.5f / 72;
 
-    scalar vertical_scale = simple_def.height / 1.7;
+    scalar vertical_scale = simple_def.height / 1.7f;
     // Scale horizontally at a lower rate.
-    scalar horizontal_scale = 0.2 + vertical_scale * 0.8;
+    scalar horizontal_scale = 0.2f + vertical_scale * 0.8f;
     auto scale = vector3{horizontal_scale, vertical_scale, horizontal_scale};
 
-    rag_def.head_size         = scale * 2 * vector3{0.075, 0.09, 0.105};
-    rag_def.neck_size         = scale * 2 * vector3{0.06, 0.065, 0.06};
-    rag_def.torso_upper_size  = scale * 2 * vector3{0.17, 0.108, 0.095};
-    rag_def.torso_middle_size = scale * 2 * vector3{0.151, 0.084, 0.07};
-    rag_def.torso_lower_size  = scale * 2 * vector3{0.155, 0.065, 0.086};
-    rag_def.hip_size          = scale * 2 * vector3{0.17, 0.07, 0.1};
-    rag_def.leg_upper_size    = scale * 2 * vector3{0.075, 0.205, 0.075};
-    rag_def.leg_lower_size    = scale * 2 * vector3{0.06, 0.205, 0.06};
-    rag_def.foot_size         = scale * 2 * vector3{0.05, 0.04, 0.13};
+    rag_def.head_size         = scale * 2 * vector3{0.075f, 0.09f, 0.105f};
+    rag_def.neck_size         = scale * 2 * vector3{0.06f, 0.065f, 0.06f};
+    rag_def.torso_upper_size  = scale * 2 * vector3{0.17f, 0.108f, 0.095f};
+    rag_def.torso_middle_size = scale * 2 * vector3{0.151f, 0.084f, 0.07f};
+    rag_def.torso_lower_size  = scale * 2 * vector3{0.155f, 0.065f, 0.086f};
+    rag_def.hip_size          = scale * 2 * vector3{0.17f, 0.07f, 0.1f};
+    rag_def.leg_upper_size    = scale * 2 * vector3{0.075f, 0.205f, 0.075f};
+    rag_def.leg_lower_size    = scale * 2 * vector3{0.06f, 0.205f, 0.06f};
+    rag_def.foot_size         = scale * 2 * vector3{0.05f, 0.04f, 0.13f};
 
     // Arms are initially oriented horizontally, thus flip the scale.
     scale = vector3{vertical_scale, horizontal_scale, horizontal_scale};
-    rag_def.arm_upper_size    = scale * 2 * vector3{0.135, 0.05, 0.05};
-    rag_def.arm_lower_size    = scale * 2 * vector3{0.135, 0.04, 0.04};
-    rag_def.hand_size         = scale * 2 * vector3{0.065, 0.045, 0.045};
+    rag_def.arm_upper_size    = scale * 2 * vector3{0.135f, 0.05f, 0.05f};
+    rag_def.arm_lower_size    = scale * 2 * vector3{0.135f, 0.04f, 0.04f};
+    rag_def.hand_size         = scale * 2 * vector3{0.065f, 0.045f, 0.045f};
 
     rag_def.shape_type = simple_def.shape_type;
 
@@ -76,12 +76,12 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
         def.mass = rag_def.head_mass;
         auto pos_y =
             rag_def.head_size.y / 2 +
-            rag_def.neck_size.y * scalar(0.627) +
+            rag_def.neck_size.y * scalar(0.627f) +
             rag_def.torso_upper_size.y +
             rag_def.torso_middle_size.y +
             rag_def.torso_lower_size.y +
             rag_def.hip_size.y / 2;
-        def.position = to_world_space({0, pos_y, -0.025}, rag_def.position, rag_def.orientation);
+        def.position = to_world_space({0, pos_y, -0.025f}, rag_def.position, rag_def.orientation);
         def.orientation = rag_def.orientation;
 
         switch (rag_def.shape_type) {
@@ -105,7 +105,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
         def.material->friction = rag_def.friction;
         def.mass = rag_def.neck_mass;
         auto pos_y =
-            rag_def.neck_size.y * scalar(0.627) / 2 +
+            rag_def.neck_size.y * scalar(0.627f) / 2 +
             rag_def.torso_upper_size.y +
             rag_def.torso_middle_size.y +
             rag_def.torso_lower_size.y +
@@ -232,7 +232,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
         entities.hip = make_rigidbody(registry, def);
     }
 
-    auto leg_pos_x = rag_def.hip_size.x / 2 - (rag_def.leg_upper_size.x - scalar(0.0072)) / 2;
+    auto leg_pos_x = rag_def.hip_size.x / 2 - (rag_def.leg_upper_size.x - scalar(0.0072f)) / 2;
 
     /* Upper legs */
     for (auto i = 0; i < 2; ++i) {
@@ -324,7 +324,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
         rag_def.hip_size.y / 2;
 
     auto shoulder_size = vector3{
-        rag_def.torso_upper_size.x * scalar(0.352),
+        rag_def.torso_upper_size.x * scalar(0.352f),
         rag_def.arm_upper_size.y, rag_def.arm_upper_size.z};
 
     auto rot_z_pi = quaternion_axis_angle({0, 0, 1}, pi);
@@ -336,7 +336,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
         def.material->friction = rag_def.friction;
         def.mass = rag_def.shoulder_mass;
         def.inertia = diagonal_matrix(moment_of_inertia_solid_box(def.mass, shoulder_size));
-        auto pos_x = rag_def.torso_upper_size.x / 2 * scalar(0.65) * to_sign(i == 0);
+        auto pos_x = rag_def.torso_upper_size.x / 2 * scalar(0.65f) * to_sign(i == 0);
         auto pos_y = torso_upper_top - rag_def.arm_upper_size.y / 2;
 
         def.position = to_world_space({pos_x, pos_y, 0}, rag_def.position, rag_def.orientation);
@@ -477,7 +477,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             con.span_tan[0] = std::tan(to_radians(10));
             con.span_tan[1] = std::tan(to_radians(20));
             con.bump_stop_stiffness = 5000;
-            con.bump_stop_length = 0.05;
+            con.bump_stop_length = 0.05f;
         });
 
     make_constraint<cvjoint_constraint>(
@@ -492,8 +492,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             cvjoint.reset_angle(
                 registry.get<orientation>(entities.hip),
                 registry.get<orientation>(entities.torso_lower));
-            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02);
-            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2);
+            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02f);
+            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2f);
             cvjoint.twist_bump_stop_angle = to_radians(4);
             cvjoint.twist_bump_stop_stiffness = to_Nm_per_radian(5);
         });
@@ -510,7 +510,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             con.span_tan[0] = std::tan(to_radians(16));
             con.span_tan[1] = std::tan(to_radians(30));
             con.bump_stop_stiffness = 5000;
-            con.bump_stop_length = 0.05;
+            con.bump_stop_length = 0.05f;
         });
 
     make_constraint<cvjoint_constraint>(
@@ -525,8 +525,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             cvjoint.reset_angle(
                 registry.get<orientation>(entities.torso_lower),
                 registry.get<orientation>(entities.torso_middle));
-            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02);
-            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2);
+            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02f);
+            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2f);
             cvjoint.twist_bump_stop_angle = to_radians(4);
             cvjoint.twist_bump_stop_stiffness = to_Nm_per_radian(5);
         });
@@ -543,7 +543,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             con.span_tan[0] = std::tan(to_radians(18));
             con.span_tan[1] = std::tan(to_radians(32));
             con.bump_stop_stiffness = 5000;
-            con.bump_stop_length = 0.05;
+            con.bump_stop_length = 0.05f;
         });
 
     make_constraint<cvjoint_constraint>(
@@ -558,8 +558,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             cvjoint.reset_angle(
                 registry.get<orientation>(entities.torso_middle),
                 registry.get<orientation>(entities.torso_upper));
-            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02);
-            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2);
+            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02f);
+            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2f);
             cvjoint.twist_bump_stop_angle = to_radians(4);
             cvjoint.twist_bump_stop_stiffness = to_Nm_per_radian(5);
         });
@@ -576,14 +576,14 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             con.span_tan[0] = std::tan(to_radians(16));
             con.span_tan[1] = std::tan(to_radians(32));
             con.bump_stop_stiffness = 3000;
-            con.bump_stop_length = 0.05;
+            con.bump_stop_length = 0.05f;
         });
 
     make_constraint<cvjoint_constraint>(
         registry, entities.torso_upper_neck_constraint, entities.torso_upper, entities.neck,
         [&](cvjoint_constraint &cvjoint) {
             cvjoint.pivot[0] = {0, rag_def.torso_upper_size.y / 2, 0};
-            cvjoint.pivot[1] = {0, -rag_def.neck_size.y * scalar(0.33), 0};
+            cvjoint.pivot[1] = {0, -rag_def.neck_size.y * scalar(0.33f), 0};
             cvjoint.frame[0] = matrix3x3_columns(vector3_y, -vector3_x, vector3_z);
             cvjoint.frame[1] = matrix3x3_columns(vector3_y, -vector3_x, vector3_z);
             cvjoint.twist_min = to_radians(-30);
@@ -591,8 +591,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             cvjoint.reset_angle(
                 registry.get<orientation>(entities.torso_upper),
                 registry.get<orientation>(entities.neck));
-            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02);
-            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2);
+            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02f);
+            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2f);
             cvjoint.twist_bump_stop_angle = to_radians(4);
             cvjoint.twist_bump_stop_stiffness = to_Nm_per_radian(5);
         });
@@ -604,19 +604,19 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
         registry, entities.neck_head_constraint, entities.neck, entities.head,
         [&](cone_constraint &con) {
             con.pivot[0] = {0, rag_def.neck_size.y / 2, 0};
-            con.pivot[1] = {0, rag_def.head_size.y, 0.025};
+            con.pivot[1] = {0, rag_def.head_size.y, 0.025f};
             con.frame = matrix3x3_columns(vector3_y, -vector3_x, vector3_z);
             con.span_tan[0] = std::tan(to_radians(16));
             con.span_tan[1] = std::tan(to_radians(32));
             con.bump_stop_stiffness = 5000;
-            con.bump_stop_length = 0.05;
+            con.bump_stop_length = 0.05f;
         });
 
     make_constraint<cvjoint_constraint>(
         registry, entities.neck_head_constraint, entities.neck, entities.head,
         [&](cvjoint_constraint &cvjoint) {
             cvjoint.pivot[0] = {0, rag_def.neck_size.y / 2, 0};
-            cvjoint.pivot[1] = {0, -(rag_def.head_size.y / 2 - rag_def.neck_size.y * scalar(0.2)), 0.025};
+            cvjoint.pivot[1] = {0, -(rag_def.head_size.y / 2 - rag_def.neck_size.y * scalar(0.2f)), 0.025f};
             cvjoint.frame[0] = matrix3x3_columns(vector3_y, -vector3_x, vector3_z);
             cvjoint.frame[1] = matrix3x3_columns(vector3_y, -vector3_x, vector3_z);
             cvjoint.twist_min = to_radians(-30);
@@ -624,8 +624,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
             cvjoint.reset_angle(
                 registry.get<orientation>(entities.neck),
                 registry.get<orientation>(entities.head));
-            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02);
-            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2);
+            cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02f);
+            cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2f);
             cvjoint.twist_bump_stop_angle = to_radians(4);
             cvjoint.twist_bump_stop_stiffness = to_Nm_per_radian(5);
         });
@@ -634,7 +634,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
     for (auto i = 0; i < 2; ++i) {
         auto leg = std::array{entities.leg_upper_left, entities.leg_upper_right}[i];
         scalar side = to_sign(i == 0);
-        auto cone_pivot0 = vector3{side * (rag_def.hip_size.x / 2 - (rag_def.leg_upper_size.x - scalar(0.0072)) / 2), 0, 0};
+        auto cone_pivot0 = vector3{side * (rag_def.hip_size.x / 2 - (rag_def.leg_upper_size.x - scalar(0.0072f)) / 2), 0, 0};
         auto cone_rot =
             quaternion_axis_angle({1, 0, 0}, to_radians(50)) *
             quaternion_axis_angle({0, 0, 1}, to_radians(10 * side));
@@ -651,7 +651,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 con.span_tan[0] = std::tan(to_radians(45));
                 con.span_tan[1] = std::tan(to_radians(70));
                 con.bump_stop_stiffness = 5000;
-                con.bump_stop_length = 0.05;
+                con.bump_stop_length = 0.05f;
             });
 
         make_constraint<cvjoint_constraint>(registry, con_entity, entities.hip, leg,
@@ -667,8 +667,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                     registry.get<orientation>(entities.hip),
                     registry.get<orientation>(leg));
 
-                cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02);
-                cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2);
+                cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02f);
+                cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2f);
                 cvjoint.twist_bump_stop_angle = to_radians(4);
                 cvjoint.twist_bump_stop_stiffness = to_Nm_per_radian(5);
             });
@@ -726,7 +726,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 con.span_tan[0] = std::tan(to_radians(24));
                 con.span_tan[1] = std::tan(to_radians(50));
                 con.bump_stop_stiffness = 3000;
-                con.bump_stop_length = 0.03;
+                con.bump_stop_length = 0.03f;
             });
 
         make_constraint<cvjoint_constraint>(registry, con_entity, ankle.first, ankle.second,
@@ -738,8 +738,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 cvjoint.reset_angle(
                     registry.get<orientation>(ankle.first),
                     registry.get<orientation>(ankle.second));
-                cvjoint.bend_friction_torque = to_Nm_per_radian(0.005);
-                cvjoint.bend_damping = to_Nm_per_radian(0.05);
+                cvjoint.bend_friction_torque = to_Nm_per_radian(0.005f);
+                cvjoint.bend_damping = to_Nm_per_radian(0.05f);
             });
 
         *std::array{
@@ -757,8 +757,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
         auto cone_rot =
             quaternion_axis_angle({0, 0, 1}, to_radians(15 * side)) *
             quaternion_axis_angle({0, 1, 0}, to_radians(15 * side));
-        auto shoulder_size_x = rag_def.torso_upper_size.x * scalar(0.352);
-        auto shoulder_pos_x = rag_def.torso_upper_size.x / 2 * scalar(0.65);
+        auto shoulder_size_x = rag_def.torso_upper_size.x * scalar(0.352f);
+        auto shoulder_pos_x = rag_def.torso_upper_size.x / 2 * scalar(0.65f);
         auto cone_pivot0 = vector3{(shoulder_pos_x - shoulder_size_x / 2) * side,
                              rag_def.torso_upper_size.y / 2 - rag_def.arm_upper_size.y / 2, 0};
 
@@ -773,7 +773,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 con.span_tan[0] = std::tan(to_radians(30));
                 con.span_tan[1] = std::tan(to_radians(40));
                 con.bump_stop_stiffness = 3000;
-                con.bump_stop_length = 0.03;
+                con.bump_stop_length = 0.03f;
             });
 
         make_constraint<cvjoint_constraint>(registry, con_entity, entities.torso_upper, shoulder,
@@ -787,8 +787,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 cvjoint.reset_angle(
                     registry.get<orientation>(entities.torso_upper),
                     registry.get<orientation>(shoulder));
-                cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02);
-                cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2);
+                cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02f);
+                cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2f);
                 cvjoint.twist_bump_stop_angle = to_radians(2);
                 cvjoint.twist_bump_stop_stiffness = to_Nm_per_radian(5);
             });
@@ -819,7 +819,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 con.span_tan[0] = std::tan(to_radians(45));
                 con.span_tan[1] = std::tan(to_radians(45));
                 con.bump_stop_stiffness = 3000;
-                con.bump_stop_length = 0.03;
+                con.bump_stop_length = 0.03f;
             });
 
         make_constraint<cvjoint_constraint>(registry, con_entity, shoulder, arm,
@@ -833,8 +833,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 cvjoint.reset_angle(
                     registry.get<orientation>(shoulder),
                     registry.get<orientation>(arm));
-                cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02);
-                cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2);
+                cvjoint.twist_friction_torque = cvjoint.bend_friction_torque = to_Nm_per_radian(0.02f);
+                cvjoint.twist_damping = cvjoint.bend_damping = to_Nm_per_radian(0.2f);
                 cvjoint.twist_bump_stop_angle = to_radians(4);
                 cvjoint.twist_bump_stop_stiffness = to_Nm_per_radian(5);
             });
@@ -858,8 +858,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 hinge.set_axes({0, 1, 0}, {0, 1, 0});
                 hinge.angle_min = 0;
                 hinge.angle_max = to_radians(140);
-                hinge.damping = 0.1;
-                hinge.torque = 0.02;
+                hinge.damping = 0.1f;
+                hinge.torque = 0.02f;
                 hinge.bump_stop_angle = to_radians(10);
                 hinge.bump_stop_stiffness = to_Nm_per_radian(5);
                 hinge.reset_angle(
@@ -882,8 +882,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 hinge.set_axes({1, 0, 0}, {1, 0, 0});
                 hinge.angle_min = -pi_half;
                 hinge.angle_max = pi_half;
-                hinge.damping = 0.1;
-                hinge.torque = 0.02;
+                hinge.damping = 0.1f;
+                hinge.torque = 0.02f;
                 hinge.bump_stop_angle = to_radians(10);
                 hinge.bump_stop_stiffness = to_Nm_per_radian(5);
                 hinge.reset_angle(
@@ -908,7 +908,7 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 con.span_tan[0] = std::tan(to_radians(80));
                 con.span_tan[1] = std::tan(to_radians(30));
                 con.bump_stop_stiffness = 2000;
-                con.bump_stop_length = 0.03;
+                con.bump_stop_length = 0.03f;
             });
 
         make_constraint<cvjoint_constraint>(registry, con_entity, twist, hand,
@@ -922,8 +922,8 @@ ragdoll_entities make_ragdoll(entt::registry &registry, const ragdoll_def &rag_d
                 cvjoint.reset_angle(
                     registry.get<orientation>(twist),
                     registry.get<orientation>(hand));
-                cvjoint.bend_friction_torque = to_Nm_per_radian(0.004);
-                cvjoint.bend_damping = to_Nm_per_radian(0.02);
+                cvjoint.bend_friction_torque = to_Nm_per_radian(0.004f);
+                cvjoint.bend_damping = to_Nm_per_radian(0.02f);
             });
 
         *std::array{&entities.wrist_left_constraint, &entities.wrist_right_constraint}[i] = con_entity;

--- a/src/edyn/util/rigidbody.cpp
+++ b/src/edyn/util/rigidbody.cpp
@@ -565,7 +565,7 @@ void rigidbody_replace_kind_tags(entt::registry &registry, entt::entity entity, 
     }
 }
 
-void rigidbody_assert_supports_kind(entt::registry &registry, entt::entity entity, rigidbody_kind kind) {
+void rigidbody_assert_supports_kind([[maybe_unused]] entt::registry &registry, [[maybe_unused]] entt::entity entity, [[maybe_unused]] rigidbody_kind kind) {
 #ifndef EDYN_DISABLE_ASSERT
     if (kind == rigidbody_kind::rb_dynamic) {
         auto &mass = registry.get<edyn::mass>(entity);

--- a/src/edyn/util/shape_io.cpp
+++ b/src/edyn/util/shape_io.cpp
@@ -57,12 +57,12 @@ static void read_face(std::istringstream &iss,
                       std::vector<uint32_t> &faces,
                       uint32_t offset, bool triangulate) {
     // Store where this face starts in the `indices` array.
-    faces.push_back(indices.size());
+    faces.push_back(static_cast<uint32_t>(indices.size()));
 
     read_face_indices(iss, indices, offset, triangulate);
 
     // Store the number of vertices in this face.
-    auto count = indices.size() - faces.back();
+    auto count = static_cast<uint32_t>(indices.size() - faces.back());
     faces.push_back(count);
 }
 
@@ -87,7 +87,7 @@ void load_meshes_from_obj_stream(Stream &stream,
 
         if (cmd == "o") {
             if (!mesh.vertices.empty()) {
-                index_offset += mesh.vertices.size();
+                index_offset += static_cast<uint32_t>(mesh.vertices.size());
                 meshes.emplace_back(std::move(mesh));
             }
             auto iss = std::istringstream(line.substr(pos_space, line.size() - pos_space));


### PR DESCRIPTION
- Add comprehensive MSVC warning suppressions in CMakeLists.txt
- Fix unused parameter warnings with [[maybe_unused]] attributes
- Fix type conversion warnings with static_cast
- Fix uninitialized variable warnings with default initialization
- Fix variable shadowing issues by renaming conflicting variables
- Maintain cross-compiler compatibility

Warning types fixed:
- 4244: type conversion, possible data loss
- 4100: unreferenced formal parameter
- 4996: deprecated function usage
- 4701: potentially uninitialized local variable
- 4305: truncation from type1 to type2
- 4267: size_t conversion, possible data loss
- 4127: conditional expression is constant
- 4456: declaration hides previous local declaration
- 4458: declaration hides class member