### PR TITLE
Boolean collision detection

### DIFF
--- a/include/edyn/collision/collide.hpp
+++ b/include/edyn/collision/collide.hpp
@@ -19,10 +19,13 @@ struct collision_context {
 
     scalar threshold;
 
+    // If true, skips closest point calculation.
+    bool boolean_test {false};
+
     collision_context swapped() const {
         return {posB, ornB, aabbB,
                 posA, ornA, aabbA,
-                threshold};
+                threshold, boolean_test};
     }
 };
 
@@ -297,6 +300,11 @@ void collide(const compound_shape &shA, const T &shB,
         collision_result child_result;
         collide(sh, shB, child_ctx, child_result);
 
+        if (ctx.boolean_test && child_result.num_points > 0) {
+            result.set_collides();
+            return false;
+        }
+
         // The elements of A in the collision points must be transformed from the child
         // node's space into A's space.
         for (size_t i = 0; i < child_result.num_points; ++i) {
@@ -310,6 +318,8 @@ void collide(const compound_shape &shA, const T &shB,
             child_point.featureA->part = node_index;
             result.maybe_add_point(child_point);
         }
+
+        return true;
     });
 }
 
@@ -351,11 +361,18 @@ void collide(const T &shA, const paged_mesh_shape &shB,
         collision_result child_result;
         collide(shA, *trimesh, ctx, child_result);
 
+        if (ctx.boolean_test && child_result.num_points > 0) {
+            result.set_collides();
+            return false;
+        }
+
         for (size_t i = 0; i < child_result.num_points; ++i) {
             auto &child_point = child_result.point[i];
             child_point.featureB->part = mesh_idx;
             result.maybe_add_point(child_point);
         }
+
+        return true;
     });
 }
 

--- a/include/edyn/collision/collision_result.hpp
+++ b/include/edyn/collision/collision_result.hpp
@@ -47,6 +47,7 @@ struct collision_result {
 
     void add_point(const collision_point &);
     void maybe_add_point(const collision_point &);
+    void set_collides();
 };
 
 }

--- a/include/edyn/collision/query_tree.hpp
+++ b/include/edyn/collision/query_tree.hpp
@@ -24,7 +24,13 @@ void traverse_tree(const Tree &tree, NodeIdType root_id, NodeIdType null_node_id
 
         if (test_func(node)) {
             if (node.leaf()) {
-                visit_func(id);
+                if constexpr(std::is_invocable_r_v<bool, VisitFunc, NodeIdType>) {
+                    if (!visit_func(id)) {
+                        break;
+                    }
+                } else {
+                    visit_func(id);
+                }
             } else {
                 stack.push_back(node.child1);
                 stack.push_back(node.child2);

--- a/include/edyn/comp/shared_comp.hpp
+++ b/include/edyn/comp/shared_comp.hpp
@@ -77,6 +77,7 @@ using shared_components_t = decltype(std::tuple_cat(std::tuple<
     island_tag,
     rolling_tag,
     contact_started_tag,
+    collide_boolean_test_tag,
     roll_direction,
     discontinuity_accumulator,
     child_list,

--- a/include/edyn/comp/tag.hpp
+++ b/include/edyn/comp/tag.hpp
@@ -88,7 +88,7 @@ struct contact_started_tag {};
 
 /**
  * Perform a boolean test on collision detection. Only effective on sensors.
- * Assign it to a sensor if contact point information is unnecessary.
+ * Assign it to a sensor if contact point information is not needed.
  */
 struct collide_boolean_test_tag {};
 

--- a/include/edyn/comp/tag.hpp
+++ b/include/edyn/comp/tag.hpp
@@ -86,6 +86,12 @@ struct external_tag {};
  */
 struct contact_started_tag {};
 
+/**
+ * Perform a boolean test on collision detection. Only effective on sensors.
+ * Assign it to a sensor if contact point information is unnecessary.
+ */
+struct collide_boolean_test_tag {};
+
 }
 
 #endif // EDYN_COMP_TAG_HPP

--- a/include/edyn/shapes/compound_shape.hpp
+++ b/include/edyn/shapes/compound_shape.hpp
@@ -1,6 +1,7 @@
 #ifndef EDYN_SHAPES_COMPOUND_SHAPE_HPP
 #define EDYN_SHAPES_COMPOUND_SHAPE_HPP
 
+#include <type_traits>
 #include <vector>
 #include <string>
 #include <variant>
@@ -85,9 +86,17 @@ void compound_shape::visit(const AABB &aabb, Func func) const {
     tree.query(aabb, [&](auto tree_node_idx) {
         auto node_id = tree.get_node(tree_node_idx).id;
         auto &node = nodes[node_id];
+        bool ret = true;
+
         std::visit([&](auto &&shape) {
-            func(shape, node_id);
+            if constexpr(std::is_invocable_r_v<bool, Func, decltype(shape), decltype(node_id)>) {
+                ret = func(shape, node_id);
+            } else {
+                func(shape, node_id);
+            }
         }, node.shape_var);
+
+        return ret;
     });
 }
 

--- a/include/edyn/shapes/paged_triangle_mesh.hpp
+++ b/include/edyn/shapes/paged_triangle_mesh.hpp
@@ -2,6 +2,7 @@
 #define EDYN_SHAPES_PAGED_TRIANGLE_MESH_HPP
 
 #include <mutex>
+#include <type_traits>
 #include <vector>
 #include <atomic>
 #include <memory>
@@ -50,9 +51,17 @@ public:
             auto mesh_idx = m_tree.get_node(tree_node_idx).id;
             load_node_if_needed(mesh_idx);
 
-            if (m_cache[mesh_idx].trimesh) {
-                func(mesh_idx);
-                mark_recent_visit(mesh_idx);
+            if constexpr(std::is_invocable_r_v<bool, Func, decltype(mesh_idx)>) {
+                if (m_cache[mesh_idx].trimesh) {
+                    return func(mesh_idx);
+                    mark_recent_visit(mesh_idx);
+                }
+                return true;
+            } else {
+                if (m_cache[mesh_idx].trimesh) {
+                    func(mesh_idx);
+                    mark_recent_visit(mesh_idx);
+                }
             }
         });
     }

--- a/include/edyn/shapes/paged_triangle_mesh.hpp
+++ b/include/edyn/shapes/paged_triangle_mesh.hpp
@@ -53,14 +53,14 @@ public:
 
             if constexpr(std::is_invocable_r_v<bool, Func, decltype(mesh_idx)>) {
                 if (m_cache[mesh_idx].trimesh) {
-                    return func(mesh_idx);
                     mark_recent_visit(mesh_idx);
+                    return func(mesh_idx);
                 }
                 return true;
             } else {
                 if (m_cache[mesh_idx].trimesh) {
-                    func(mesh_idx);
                     mark_recent_visit(mesh_idx);
+                    func(mesh_idx);
                 }
             }
         });

--- a/include/edyn/shapes/triangle_mesh.hpp
+++ b/include/edyn/shapes/triangle_mesh.hpp
@@ -1,6 +1,7 @@
 #ifndef EDYN_SHAPES_TRIANGLE_MESH_HPP
 #define EDYN_SHAPES_TRIANGLE_MESH_HPP
 
+#include <type_traits>
 #include <vector>
 #include <cstdint>
 #include "edyn/config/config.h"
@@ -116,7 +117,11 @@ public:
     void visit_triangles(const AABB &aabb, Func func) const {
         m_triangle_tree.query(aabb, [&](auto tree_node_idx) {
             auto tri_idx = m_triangle_tree.get_node(tree_node_idx).id;
-            func(tri_idx);
+            if constexpr(std::is_invocable_r_v<bool, Func, decltype(tri_idx)>) {
+                return func(tri_idx);
+            } else {
+                func(tri_idx);
+            }
         });
     }
 

--- a/src/edyn/collision/collide/collide_box_box.cpp
+++ b/src/edyn/collision/collide/collide_box_box.cpp
@@ -102,6 +102,11 @@ void collide(const box_shape &shA, const box_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     box_feature featureA, featureB;
     size_t feature_indexA, feature_indexB;
     scalar projectionA, projectionB;

--- a/src/edyn/collision/collide/collide_box_mesh.cpp
+++ b/src/edyn/collision/collide/collide_box_mesh.cpp
@@ -128,6 +128,11 @@ static void collide_box_triangle(
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
@@ -406,6 +411,7 @@ void collide(const box_shape &box, const triangle_mesh &mesh,
 
     mesh.visit_triangles(visit_aabb, [&](auto tri_idx) {
         collide_box_triangle(box, mesh, tri_idx, box_axes, ctx, result);
+        return !(ctx.boolean_test && result.num_points > 0);
     });
 }
 

--- a/src/edyn/collision/collide/collide_box_plane.cpp
+++ b/src/edyn/collision/collide/collide_box_plane.cpp
@@ -20,6 +20,11 @@ void collide(const box_shape &shA, const plane_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto vertices = std::array<vector3, 4>{};
     auto num_vertices = size_t{};
 

--- a/src/edyn/collision/collide/collide_capsule_box.cpp
+++ b/src/edyn/collision/collide/collide_capsule_box.cpp
@@ -82,6 +82,11 @@ void collide(const capsule_shape &shA, const box_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     scalar proj_capsule_vertices[] = {
         dot(capsule_vertices[0], sep_axis),
         dot(capsule_vertices[1], sep_axis)

--- a/src/edyn/collision/collide/collide_capsule_capsule.cpp
+++ b/src/edyn/collision/collide/collide_capsule_capsule.cpp
@@ -28,6 +28,11 @@ void collide(const capsule_shape &shA, const capsule_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     vector3 normal;
     scalar distance;
 
@@ -36,7 +41,7 @@ void collide(const capsule_shape &shA, const capsule_shape &shB,
         normal = (closestA[0] - closestB[0]) / dist;
         distance = dist - shA.radius - shB.radius;
     } else {
-        // Seguments intersect in 3D.
+        // Segments intersect in 3D.
         auto axisA = verticesA[1] - verticesA[0];
         auto axisB = verticesB[1] - verticesB[0];
         normal = cross(axisA, axisB);

--- a/src/edyn/collision/collide/collide_capsule_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_capsule_cylinder.cpp
@@ -138,6 +138,11 @@ void collide(const capsule_shape &shA, const cylinder_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     scalar proj_capsule_vertices[] = {
         dot(capsule_vertices[0], sep_axis),
         dot(capsule_vertices[1], sep_axis)

--- a/src/edyn/collision/collide/collide_capsule_mesh.cpp
+++ b/src/edyn/collision/collide/collide_capsule_mesh.cpp
@@ -100,6 +100,11 @@ static void collide_capsule_triangle(
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     scalar proj_capsule_vertices[] = {
         dot(capsule_vertices[0], sep_axis),
         dot(capsule_vertices[1], sep_axis)
@@ -261,6 +266,7 @@ void collide(const capsule_shape &capsule, const triangle_mesh &mesh,
 
     mesh.visit_triangles(visit_aabb, [&](auto tri_idx) {
         collide_capsule_triangle(capsule, mesh, tri_idx, capsule_vertices, ctx, result);
+        return !(ctx.boolean_test && result.num_points > 0);
     });
 }
 

--- a/src/edyn/collision/collide/collide_capsule_plane.cpp
+++ b/src/edyn/collision/collide/collide_capsule_plane.cpp
@@ -29,6 +29,11 @@ void collide(const capsule_shape &shA, const plane_shape &shB,
 
         if (distance > ctx.threshold) continue;
 
+        if (ctx.boolean_test) {
+            result.set_collides();
+            return;
+        }
+
         auto vertex = capsule_vertices[i];
         auto pivotA_world = vertex - shB.normal * shA.radius;
         auto pivotA = to_object_space(pivotA_world, ctx.posA, ctx.ornA);

--- a/src/edyn/collision/collide/collide_capsule_sphere.cpp
+++ b/src/edyn/collision/collide/collide_capsule_sphere.cpp
@@ -18,6 +18,11 @@ void collide(const capsule_shape &shA, const sphere_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto normal = closest - ctx.posB;
     auto normal_len_sqr = length_sqr(normal);
     scalar distance;

--- a/src/edyn/collision/collide/collide_compound_compound.cpp
+++ b/src/edyn/collision/collide/collide_compound_compound.cpp
@@ -26,6 +26,15 @@ void collide(const compound_shape &shA, const compound_shape &shB,
             collide(shA, sh, child_ctx, child_result);
         }, nodeB.shape_var);
 
+        if (ctx.boolean_test) {
+            if (child_result.num_points > 0) {
+                result.set_collides();
+                return;
+            }
+
+            continue;
+        }
+
         // Transform the B elements of the result points from child shape space
         // into B's space.
         for (size_t i = 0; i < child_result.num_points; ++i) {

--- a/src/edyn/collision/collide/collide_compound_mesh.cpp
+++ b/src/edyn/collision/collide/collide_compound_mesh.cpp
@@ -26,6 +26,15 @@ void collide(const compound_shape &compound, const triangle_mesh &mesh,
             collide(sh, mesh, child_ctx, child_result);
         }, node.shape_var);
 
+        if (ctx.boolean_test) {
+            if (child_result.num_points > 0) {
+                result.set_collides();
+                return;
+            }
+
+            continue;
+        }
+
         // The elements of A in the collision points must be transformed from
         // the child node's space into the compound's space.
         for (size_t i = 0; i < child_result.num_points; ++i) {

--- a/src/edyn/collision/collide/collide_compound_plane.cpp
+++ b/src/edyn/collision/collide/collide_compound_plane.cpp
@@ -25,6 +25,15 @@ void collide(const compound_shape &shA, const plane_shape &shB,
             collide(sh, shB, child_ctx, child_result);
         }, node.shape_var);
 
+        if (ctx.boolean_test) {
+            if (child_result.num_points > 0) {
+                result.set_collides();
+                return;
+            }
+
+            continue;
+        }
+
         for (size_t i = 0; i < child_result.num_points; ++i) {
             auto &child_point = child_result.point[i];
             child_point.pivotA = to_world_space(child_point.pivotA, node.position, node.orientation);

--- a/src/edyn/collision/collide/collide_cylinder_box.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_box.cpp
@@ -164,6 +164,11 @@ void collide(const cylinder_shape &shA, const box_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     cylinder_feature featureA;
     size_t feature_indexA;
     shA.support_feature(posA, ornA, -sep_axis, featureA, feature_indexA,

--- a/src/edyn/collision/collide/collide_cylinder_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_cylinder.cpp
@@ -169,6 +169,11 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     cylinder_feature featureA;
     size_t feature_indexA;
     shA.support_feature(posA, ornA, -sep_axis, featureA, feature_indexA,
@@ -190,7 +195,6 @@ void collide(const cylinder_shape &shA, const cylinder_shape &shB,
         auto pivotB_world = to_world_space(pivotB, posB, ornB);
         return dot(pivotA_world - pivotB_world, sep_axis);
     };
-
 
     // Index of vector element in cylinder object space that represents the
     // cylinder axis followed by the indices of the elements of the axes

--- a/src/edyn/collision/collide/collide_cylinder_mesh.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_mesh.cpp
@@ -141,6 +141,11 @@ void collide_cylinder_triangle(
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     cylinder_feature cyl_feature;
     size_t cyl_feature_index;
     cylinder.support_feature(posA, ornA, -sep_axis, cyl_feature, cyl_feature_index,
@@ -436,6 +441,7 @@ void collide(const cylinder_shape &cylinder, const triangle_mesh &mesh,
     mesh.visit_triangles(visit_aabb, [&](auto tri_idx) {
         collide_cylinder_triangle(cylinder, mesh, tri_idx,
                                   cylinder_axis, cylinder_vertices, ctx, result);
+        return !(ctx.boolean_test && result.num_points > 0);
     });
 }
 

--- a/src/edyn/collision/collide/collide_cylinder_plane.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_plane.cpp
@@ -19,6 +19,11 @@ void collide(const cylinder_shape &shA, const plane_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     cylinder_feature featureA;
     size_t feature_indexA;
     shA.support_feature(posA, ornA, -normal, featureA, feature_indexA,

--- a/src/edyn/collision/collide/collide_cylinder_sphere.cpp
+++ b/src/edyn/collision/collide/collide_cylinder_sphere.cpp
@@ -59,6 +59,11 @@ void collide(const cylinder_shape &shA, const sphere_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto normal = closest - posB;
     const auto n_len_sqr = length_sqr(normal);
     const auto n_len = std::sqrt(n_len_sqr);

--- a/src/edyn/collision/collide/collide_polyhedron_box.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_box.cpp
@@ -129,6 +129,11 @@ void collide(const polyhedron_shape &shA, const box_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto polygon = point_cloud_support_polygon(
         meshA.vertices.begin(), meshA.vertices.end(), vector3_zero,
         sep_axis, projection_poly, true, support_feature_tolerance);

--- a/src/edyn/collision/collide/collide_polyhedron_capsule.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_capsule.cpp
@@ -72,6 +72,11 @@ void collide(const polyhedron_shape &shA, const capsule_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     scalar proj_capsule_vertices[] = {
         dot(capsule_vertices[0], sep_axis),
         dot(capsule_vertices[1], sep_axis)

--- a/src/edyn/collision/collide/collide_polyhedron_cylinder.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_cylinder.cpp
@@ -154,6 +154,11 @@ void collide(const polyhedron_shape &shA, const cylinder_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     // Separating axis is in A's space.
     auto normal = rotate(ctx.ornA, sep_axis);
 

--- a/src/edyn/collision/collide/collide_polyhedron_mesh.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_mesh.cpp
@@ -150,6 +150,11 @@ static void collide_polyhedron_triangle(
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto polygon = point_cloud_support_polygon(
         rmesh.vertices.begin(), rmesh.vertices.end(), vector3_zero,
         sep_axis, projection_poly, true, support_feature_tolerance);
@@ -267,6 +272,7 @@ void collide(const polyhedron_shape &poly, const triangle_mesh &mesh,
 
     mesh.visit_triangles(visit_aabb, [&](auto tri_idx) {
         collide_polyhedron_triangle(poly, mesh, tri_idx, ctx, result);
+        return !(ctx.boolean_test && result.num_points > 0);
     });
 }
 

--- a/src/edyn/collision/collide/collide_polyhedron_plane.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_plane.cpp
@@ -21,6 +21,11 @@ void collide(const polyhedron_shape &shA, const plane_shape &shB,
 
     if (distance > ctx.threshold) return;
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto polygon = point_cloud_support_polygon(
         rmeshA.vertices.begin(), rmeshA.vertices.end(), vector3_zero,
         normal, proj_poly, true, support_feature_tolerance);

--- a/src/edyn/collision/collide/collide_polyhedron_polyhedron.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_polyhedron.cpp
@@ -159,6 +159,11 @@ void collide(const polyhedron_shape &shA, const polyhedron_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto polygonA = point_cloud_support_polygon(
         rmeshA.vertices.begin(), rmeshA.vertices.end(), posA,
         sep_axis, projectionA, true, support_feature_tolerance);

--- a/src/edyn/collision/collide/collide_polyhedron_sphere.cpp
+++ b/src/edyn/collision/collide/collide_polyhedron_sphere.cpp
@@ -41,6 +41,11 @@ void collide(const polyhedron_shape &shA, const sphere_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto polygon = point_cloud_support_polygon(
         meshA.vertices.begin(), meshA.vertices.end(), vector3_zero,
         sep_axis, projection_poly, true, support_feature_tolerance);

--- a/src/edyn/collision/collide/collide_sphere_box.cpp
+++ b/src/edyn/collision/collide/collide_sphere_box.cpp
@@ -21,6 +21,11 @@ void collide(const sphere_shape &shA, const box_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     scalar center_distance;
     auto normal_attachment = contact_normal_attachment::none;
 

--- a/src/edyn/collision/collide/collide_sphere_mesh.cpp
+++ b/src/edyn/collision/collide/collide_sphere_mesh.cpp
@@ -73,6 +73,11 @@ static void collide_sphere_triangle(
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     collision_result::collision_point point;
     point.normal = sep_axis;
     point.distance = distance;
@@ -121,6 +126,7 @@ void collide(const sphere_shape &sphere, const triangle_mesh &mesh,
 
     mesh.visit_triangles(visit_aabb, [&](auto tri_idx) {
         collide_sphere_triangle(sphere, mesh, tri_idx, ctx, result);
+        return !(ctx.boolean_test && result.num_points > 0);
     });
 }
 

--- a/src/edyn/collision/collide/collide_sphere_plane.cpp
+++ b/src/edyn/collision/collide/collide_sphere_plane.cpp
@@ -9,7 +9,12 @@ void collide(const sphere_shape &sphere, const plane_shape &plane,
     auto d = ctx.posA - center;
     auto l = dot(normal, d);
 
-    if (l > sphere.radius) {
+    if (l > sphere.radius + ctx.threshold) {
+        return;
+    }
+
+    if (ctx.boolean_test) {
+        result.set_collides();
         return;
     }
 

--- a/src/edyn/collision/collide/collide_sphere_sphere.cpp
+++ b/src/edyn/collision/collide/collide_sphere_sphere.cpp
@@ -12,6 +12,11 @@ void collide(const sphere_shape &shA, const sphere_shape &shB,
         return;
     }
 
+    if (ctx.boolean_test) {
+        result.set_collides();
+        return;
+    }
+
     auto dist = std::sqrt(dist_sqr);
     auto dn = dist > EDYN_EPSILON ? d / dist : vector3_x;
     auto rA = -dn * shA.radius;

--- a/src/edyn/collision/collision_result.cpp
+++ b/src/edyn/collision/collision_result.cpp
@@ -1,4 +1,5 @@
 #include "edyn/collision/collision_result.hpp"
+#include "edyn/collision/contact_normal_attachment.hpp"
 #include "edyn/math/geom.hpp"
 
 namespace edyn {
@@ -31,5 +32,15 @@ void collision_result::maybe_add_point(const collision_result::collision_point &
         point[res.index] = new_point;
     }
 }
+
+void collision_result::set_collides() {
+    num_points = 1;
+    auto &cp = point[0];
+    cp.pivotA = vector3_zero;
+    cp.pivotB = vector3_zero;
+    cp.normal = vector3_x;
+    cp.normal_attachment = contact_normal_attachment::normal_on_B;
+}
+
 
 }

--- a/src/edyn/util/collision_util.cpp
+++ b/src/edyn/util/collision_util.cpp
@@ -465,6 +465,12 @@ void detect_collision(entt::registry &registry, std::array<entt::entity, 2> body
         auto shape_indexB = body_view.get<shape_index>(body[1]);
         auto ctx = collision_context{originA, ornA, aabbA, originB, ornB, aabbB, collision_threshold};
 
+        // Do a boolean test if a body is a sensor and has a collide_boolean_test_tag.
+        auto material_view = registry.view<material>();
+        auto boolean_view = registry.view<collide_boolean_test_tag>();
+        ctx.boolean_test = (!material_view->contains(body[0]) && boolean_view.contains(body[0])) ||
+                           (!material_view->contains(body[1]) && boolean_view.contains(body[1]));
+
         visit_shape(shape_indexA, body[0], shapes_views_tuple, [&](auto &&shA) {
             visit_shape(shape_indexB, body[1], shapes_views_tuple, [&](auto &&shB) {
                 collide(shA, shB, ctx, result);

--- a/src/edyn/util/collision_util.cpp
+++ b/src/edyn/util/collision_util.cpp
@@ -323,7 +323,7 @@ entt::entity create_contact_point(entt::registry &registry,
                                   const collision_result::collision_point& rp,
                                   const std::optional<transient> &transient_contact) {
     EDYN_ASSERT(length_sqr(rp.normal) > EDYN_EPSILON);
-    EDYN_ASSERT(manifold_state.num_points <= max_contacts);
+    EDYN_ASSERT(manifold_state.num_points < max_contacts);
 
     auto cp = contact_point{};
     cp.pivotA = rp.pivotA;
@@ -432,6 +432,7 @@ void destroy_contact_point(entt::registry &registry, entt::entity contact_entity
         registry.patch<contact_point_list>(current_entity);
     }
 
+    EDYN_ASSERT(manifold_state.num_points > 0);
     --manifold_state.num_points;
     registry.patch<contact_manifold_state>(manifold_entity);
     registry.destroy(contact_entity);


### PR DESCRIPTION
Perform collision detection without closest point calculation.
Avoids wasteful computation when using sensor bodies where the only information needed is whether there's intersection or not.